### PR TITLE
Multi-hierarchy: stop splitting hierarchyType on first underscore

### DIFF
--- a/apps/health_campaign_field_worker_app/lib/utils/runtime_hierarchy.dart
+++ b/apps/health_campaign_field_worker_app/lib/utils/runtime_hierarchy.dart
@@ -3,18 +3,16 @@ import 'package:flutter/foundation.dart';
 
 import 'environment_config.dart';
 
-/// Returns the active project's `hierarchyType` in its canonical
-/// schema-prefix form (already stripped of any `_<COUNTRY>` suffix —
-/// normalization happens once in [DigitDataModelSingleton.setHierarchyType]).
+/// Returns the active project's `hierarchyType` verbatim — whatever the
+/// project payload's `additionalDetails.hierarchyType` carries is what the
+/// boundary service expects (e.g. `TEST_7500`, `CONSOLEHCM`). Country lives on
+/// boundary *codes* (`TEST_7500_IN`), not on the hierarchy type.
 ///
 /// Resolution order:
 ///   1. [DigitDataModelSingleton.hierarchyType] (populated on project selection)
-///   2. [Variables.hierarchyType] from `.env`, routed through the singleton's
-///      setter so it lands in the same canonical form
+///   2. [Variables.hierarchyType] from `.env` as a missing-field fallback
 ///
-/// The env fallback is a missing-field safety net for projects whose
-/// `additionalDetails.hierarchyType` is absent — it is not a pre-selection
-/// bridge. In debug builds we assert that a project has been selected so any
+/// In debug builds we assert that a project has been selected so any
 /// pre-selection reads surface as bugs.
 String runtimeHierarchyType() {
   final fromProject = DigitDataModelSingleton().hierarchyType;
@@ -31,9 +29,5 @@ String runtimeHierarchyType() {
     }(),
   );
 
-  // Route the env fallback through the setter so the singleton applies the
-  // same country-suffix stripping, then re-read.
-  DigitDataModelSingleton()
-      .setHierarchyType(envConfig.variables.hierarchyType);
-  return DigitDataModelSingleton().hierarchyType ?? '';
+  return envConfig.variables.hierarchyType;
 }

--- a/packages/digit_data_model/lib/utils/utils.dart
+++ b/packages/digit_data_model/lib/utils/utils.dart
@@ -88,12 +88,12 @@ class DigitDataModelSingleton {
   /// project is selected (or after restoring a previously selected project on
   /// cold restart). Pass `null` on logout.
   ///
-  /// The trailing `_<COUNTRY>` suffix is stripped on write so every reader
-  /// receives the canonical schema-prefix form
-  /// (e.g. `CONSOLEHCM_NI` → `CONSOLEHCM`). This is the single point of
-  /// normalization for hierarchy values across the codebase.
+  /// Stored verbatim — the hierarchy type from `additionalDetails` is the
+  /// canonical value the boundary service expects (e.g. `TEST_7500`,
+  /// `CONSOLEHCM`). Any `_<COUNTRY>` suffix lives on boundary *codes*
+  /// (`TEST_7500_IN`), not on the hierarchy type itself.
   void setHierarchyType(String? hierarchyType) {
-    _hierarchyType = _stripCountrySuffix(hierarchyType);
+    _hierarchyType = hierarchyType;
   }
 
   // Getters for the environment configuration variables.
@@ -108,16 +108,6 @@ class DigitDataModelSingleton {
   String? get hierarchyType => _hierarchyType;
 
   EntityMapperListener? get entityMapper => _entityListener;
-}
-
-/// Strips the trailing `_<COUNTRY>` suffix from a hierarchy-style value so
-/// every consumer (boundary API, localization module keys, MDMS lookups) sees
-/// the canonical schema-prefix form. `CONSOLEHCM_NI` → `CONSOLEHCM`,
-/// `CONSOLEHCM` → `CONSOLEHCM`, `null`/`''` → unchanged.
-String? _stripCountrySuffix(String? raw) {
-  if (raw == null || raw.isEmpty) return raw;
-  final idx = raw.indexOf('_');
-  return idx == -1 ? raw : raw.substring(0, idx);
 }
 
 /// `PersistenceConfiguration` is an enum that represents the different types of persistence configurations.


### PR DESCRIPTION
The country-suffix stripping added in d84cd4d39 used indexOf('_'), which collapsed any multi-token hierarchy to its first segment. Projects whose additionalDetails.hierarchyType is TEST_7500 were being sent to the boundary API as hierarchyType=TEST, returning 400
HIERARCHY_DEFINITION_DOES_NOT_EXIST_ERR.

Store the value verbatim for now. The country suffix lives on boundary *codes* (TEST_7500_IN), not on the hierarchy type. The CONSOLEHCM_NI case the prior commit was solving will need conditional stripping (allowlist or trailing-2-letter pattern) — to be addressed once the rule is agreed.