### PR TITLE
Polio eligibility fix, VACCINATION_FAILED filter, notExists query sup…

### DIFF
--- a/apps/health_campaign_field_worker_app/lib/pages/home.dart
+++ b/apps/health_campaign_field_worker_app/lib/pages/home.dart
@@ -2753,8 +2753,7 @@ class _HomePageState extends LocalizedState<HomePage> {
                 .map((e) => e.displayName)
                 .toList()
                 .contains(element) ||
-            element == i18.home.db ||
-            (isPolio && element == i18.home.transitPostLabel))
+            element == i18.home.db)
         .where(
             (element) => !(isPolio && element == i18.home.stockSyncDataLabel))
         .toList();

--- a/apps/health_campaign_field_worker_app/lib/pages/home.dart
+++ b/apps/health_campaign_field_worker_app/lib/pages/home.dart
@@ -55,17 +55,17 @@ import '../sampleJsonConfigs/manage_stock.dart';
 import '../sampleJsonConfigs/polio_inside_household_monitoring.dart';
 import '../sampleJsonConfigs/polio_lqa_data_collection.dart';
 import '../sampleJsonConfigs/polio_stock_details.dart';
-import '../sampleJsonConfigs/registration_smc_flows.dart';
+import '../sampleJsonConfigs/registration_flows.dart';
 import '../sampleJsonConfigs/stock_reconciliation.dart';
 import '../utils/attendance_utils.dart';
 import '../utils/date_util_attendance.dart';
 import '../utils/debound.dart';
 import '../utils/environment_config.dart';
 import '../utils/flow_navigation_utils.dart';
-import '../utils/runtime_hierarchy.dart';
 import '../utils/function_registries.dart';
 import '../utils/i18_key_constants.dart' as i18;
 import '../utils/least_level_boundary_singleton.dart';
+import '../utils/runtime_hierarchy.dart';
 import '../utils/stock_downsync_utils.dart';
 import '../utils/utils.dart';
 import '../widgets/attendance/attendance_qr_scanner_button.dart';
@@ -2058,11 +2058,11 @@ class _HomePageState extends LocalizedState<HomePage> {
                     );
                   } else {
                     FlowRegistry.setConfig(
-                        sampleSMCFlows["flows"] as List<Map<String, dynamic>>);
+                        sampleFlows["flows"] as List<Map<String, dynamic>>);
                     NavigationRegistry.setupNavigation(ctx);
                     ctx.router.push(
                       FlowBuilderHomeRoute(
-                          pageName: sampleSMCFlows["initialPage"]),
+                          pageName: sampleFlows["initialPage"]),
                     );
                   }
                 } catch (e) {
@@ -2674,7 +2674,7 @@ class _HomePageState extends LocalizedState<HomePage> {
 
       i18.home.transitPostLabel: homeShowcaseData.transitPost.buildWith(
           child: HomeItemCard(
-        icon: Icons.vaccines_outlined,
+        icon: Icons.local_shipping_outlined,
         label: i18.home.transitPostLabel,
         onPressed: () {
           const module = "hcm-transit-post";
@@ -2753,7 +2753,10 @@ class _HomePageState extends LocalizedState<HomePage> {
                 .map((e) => e.displayName)
                 .toList()
                 .contains(element) ||
-            element == i18.home.db)
+            element == i18.home.db ||
+            (isPolio && element == i18.home.transitPostLabel))
+        .where(
+            (element) => !(isPolio && element == i18.home.stockSyncDataLabel))
         .toList();
 
     final showcaseKeys = filteredLabels
@@ -2844,6 +2847,10 @@ void setPackagesSingleton(BuildContext context) {
           minAge: context.selectedProjectType?.validMinAge,
           maxAge: context.selectedProjectType?.validMaxAge,
         );
+        final selectedBoundary = context.boundaryOrNull;
+        if (selectedBoundary != null) {
+          TransitPostSingleton().setBoundary(boundary: selectedBoundary);
+        }
         FlowBuilderSingleton().setInitialData(
           beneficiaryIdMinCount:
               appConfiguration.beneficiaryIdConfig?.first.minCount.toInt(),

--- a/apps/health_campaign_field_worker_app/lib/sampleJsonConfigs/registration_flows.dart
+++ b/apps/health_campaign_field_worker_app/lib/sampleJsonConfigs/registration_flows.dart
@@ -851,21 +851,12 @@ final dynamic sampleFlows = {
                       "tagType": "error"
                     }
                   },
-                  {
-                    "type": "template",
-                    "label": "HCM_HOUSEHOLD_OVERVIEW_BENEFICIARY_REFERRED_TAG",
-                    "format": "tag",
-                    "visible": "{{fn:hasReferralForCurrentCycle(item.hFReferral)}}==true && {{fn:isHead(item.member)}}==false",
-                    "fieldName": "beneficiaryReferred",
-                    "properties": {
-                      "tagType": "error"
-                    }
-                  },
+
                   {
                     "type": "template",
                     "label": "HCM_HOUSEHOLD_OVERVIEW_ADMINISTERED_SUCCESS_TAG",
                     "format": "tag",
-                    "visible": "{{fn:isDelivered(item.task.last.status)}}==true && {{fn:hasRedoseForCurrentCycle(item.task)}}==false && {{fn:checkEligibilityForAgeAndSideEffect(item.individual.0.dateOfBirth, item.task)}}==true && {{fn:hasReferralForCurrentCycle(item.hFReferral)}}==false && {{fn:isHead(item.member)}}==false",
+                    "visible": "{{fn:isDelivered(item.task.last.status)}}==true && {{fn:hasRedoseForCurrentCycle(item.task)}}==false && {{fn:checkPolioEligibility(item.individual.0.dateOfBirth, item.task)}}==true && {{fn:hasReferralForCurrentCycle(item.hFReferral)}}==false && {{fn:isHead(item.member)}}==false",
                     "fieldName": "administrationSuccess",
                     "properties": {
                       "tagType": "success",
@@ -898,7 +889,7 @@ final dynamic sampleFlows = {
                     "type": "template",
                     "label": "HCM_HOUSEHOLD_OVERVIEW_NOT_VISITED_TAG",
                     "format": "tag",
-                    "visible": "{{fn:checkEligibilityForAgeAndSideEffect(item.individual.0.dateOfBirth, item.task)}}==true && {{fn:isDelivered(item.task.last.status)}}==false && {{fn:hasReferralForCurrentCycle(item.hFReferral)}}==false && {{fn:hasUnableToDeliverForCurrentCycle(item.task)}}==false && {{fn:hasRedoseForCurrentCycle(item.task)}}==false && {{fn:isHead(item.member)}}==false",
+                    "visible": "{{fn:checkPolioEligibility(item.individual.0.dateOfBirth, item.task)}}==true && {{fn:isDelivered(item.task.last.status)}}==false && {{fn:hasReferralForCurrentCycle(item.hFReferral)}}==false && {{fn:hasUnableToDeliverForCurrentCycle(item.task)}}==false && {{fn:hasRedoseForCurrentCycle(item.task)}}==false && {{fn:isHead(item.member)}}==false",
                     "fieldName": "notVisited",
                     "properties": {
                       "tagType": "info",
@@ -909,7 +900,7 @@ final dynamic sampleFlows = {
                     "type": "template",
                     "label": "HCM_HOUSEHOLD_OVERVIEW_ACTION_BUTTON",
                     "format": "actionPopup",
-                    "visible": "{{fn:checkEligibilityForAgeAndSideEffect(item.individual.0.dateOfBirth, item.task)}} == true  && {{fn:checkAllDoseDelivered(item.task)}} == false && {{fn:hasReferralForCurrentCycle(item.hFReferral)}}==false && {{fn:hasRedoseForCurrentCycle(item.task)}}==false && {{fn:isHead(item.member)}}==false",
+                    "visible": "{{fn:checkPolioEligibility(item.individual.0.dateOfBirth, item.task)}} == true  && {{fn:checkAllDoseDelivered(item.task)}} == false && {{fn:hasReferralForCurrentCycle(item.hFReferral)}}==false && {{fn:hasRedoseForCurrentCycle(item.task)}}==false && {{fn:isHead(item.member)}}==false",
                     "fieldName": "actionButton",
                     "mandatory": true,
                     "properties": {
@@ -1374,7 +1365,9 @@ final dynamic sampleFlows = {
       "screenType": "TEMPLATE",
       "description": "HCM_HOUSEHOLD_OVERVIEW_DESCRIPTION",
       "initActions": [
-        {"actionType": "LOAD_UNIQUE_ID_POOL"},
+        {
+          "actionType": "LOAD_UNIQUE_ID_POOL"
+        },
         {
           "actionType": "SEARCH_EVENT",
           "properties": {
@@ -1697,7 +1690,7 @@ final dynamic sampleFlows = {
                     {
                       "actionType": "CLEAR_STATE",
                       "properties": {
-                        "name": "latestTask",
+                        "name": "task",
                         "filterKeys": [
                           "status",
                           "projectBeneficiary",
@@ -1748,7 +1741,46 @@ final dynamic sampleFlows = {
                         }
                       ],
                       "condition": {
-                        "expression": "selectedStatus == CLOSED_HOUSEHOLD || selectedStatus == ADMINISTRATION_FAILED || selectedStatus == INELIGIBLE || selectedStatus == VISITED"
+                        "expression": "selectedStatus == CLOSED_HOUSEHOLD || selectedStatus == INELIGIBLE || selectedStatus == VISITED"
+                      }
+                    },
+                    {
+                      "actions": [
+                        {
+                          "actionType": "SEARCH_EVENT",
+                          "properties": {
+                            "data": [
+                              {
+                                "key": "status",
+                                "value": ["ADMINISTRATION_FAILED"],
+                                "operation": "in"
+                              }
+                            ],
+                            "name": "task"
+                          }
+                        },
+                        {
+                          "actionType": "SEARCH_EVENT",
+                          "properties": {
+                            "data": [
+                              {
+                                "key": "status",
+                                "root": "task",
+                                "value": {
+                                  "values": [
+                                    "VISITED",
+                                    "ADMINISTRATION_SUCCESS"
+                                  ]
+                                },
+                                "operation": "notExists"
+                              }
+                            ],
+                            "name": "taskExclude"
+                          }
+                        }
+                      ],
+                      "condition": {
+                        "expression": "selectedStatus == ADMINISTRATION_FAILED"
                       }
                     },
                     {
@@ -1783,7 +1815,8 @@ final dynamic sampleFlows = {
                                 "value": "{{singleton.selectedProject.id}}",
                                 "operation": "equals"
                               }
-                            ]
+                            ],
+                            "name": "task"
                           }
                         }
                       ],
@@ -2189,7 +2222,9 @@ final dynamic sampleFlows = {
       "screenType": "TEMPLATE",
       "description": "HCM_SEARCH_BENEFICIARY_DESCRIPTION",
       "initActions": [
-        {"actionType": "LOAD_UNIQUE_ID_POOL"}
+        {
+          "actionType": "LOAD_UNIQUE_ID_POOL"
+        }
       ],
       "wrapperConfig": {
         "filters": [],
@@ -2273,7 +2308,8 @@ final dynamic sampleFlows = {
             "individual",
             "householdMember",
             "projectBeneficiary",
-            "task"
+            "task",
+            "hFReferral"
           ],
           "primary": "household",
           "pagination": {

--- a/packages/digit_crud_bloc/lib/repositories/helpers/multi_table_filter_resolver.dart
+++ b/packages/digit_crud_bloc/lib/repositories/helpers/multi_table_filter_resolver.dart
@@ -264,19 +264,46 @@ class MultiTableFilterResolver {
     // Fallback: one subquery per related table (current behaviour).
     final exprs = <Expression<bool>>[];
     for (final pair in pathFilterPairs) {
-      final expr = QueryBuilder.buildPrimaryKeySubqueryExpression(
-        sql: _sql,
-        path: pair.path,
-        filtersOnFirstTable: pair.filters,
-        primaryKeyColumn: primaryKeyColumn,
-      );
-      exprs.add(expr);
+      // Separate notExists filters from regular ones. notExists filters
+      // produce a NOT IN subquery (find primary records that have NO related
+      // record matching the inner condition).
+      final notExistsFilters =
+          pair.filters.where((f) => f.operator == 'notExists').toList();
+      final regularFilters =
+          pair.filters.where((f) => f.operator != 'notExists').toList();
 
-      _log(
-        'Built subquery constraint: $primaryTable.$primaryKeyField IN '
-        '(SELECT ... FROM ${pair.path.first.from} -> ${pair.path.last.from}) with '
-        '${pair.filters.length} filter(s).',
-      );
+      if (regularFilters.isNotEmpty) {
+        final expr = QueryBuilder.buildPrimaryKeySubqueryExpression(
+          sql: _sql,
+          path: pair.path,
+          filtersOnFirstTable: regularFilters,
+          primaryKeyColumn: primaryKeyColumn,
+        );
+        exprs.add(expr);
+
+        _log(
+          'Built subquery constraint: $primaryTable.$primaryKeyField IN '
+          '(SELECT ... FROM ${pair.path.first.from} -> ${pair.path.last.from}) with '
+          '${regularFilters.length} filter(s).',
+        );
+      }
+
+      if (notExistsFilters.isNotEmpty) {
+        final expr = QueryBuilder.buildPrimaryKeySubqueryExpression(
+          sql: _sql,
+          path: pair.path,
+          filtersOnFirstTable: notExistsFilters,
+          primaryKeyColumn: primaryKeyColumn,
+          negate: true,
+        );
+        exprs.add(expr);
+
+        _log(
+          'Built NOT IN subquery constraint: $primaryTable.$primaryKeyField NOT IN '
+          '(SELECT ... FROM ${pair.path.first.from} -> ${pair.path.last.from}) with '
+          '${notExistsFilters.length} notExists filter(s).',
+        );
+      }
     }
 
     return (

--- a/packages/digit_crud_bloc/lib/repositories/helpers/query_builder.dart
+++ b/packages/digit_crud_bloc/lib/repositories/helpers/query_builder.dart
@@ -42,6 +42,7 @@ class QueryBuilder {
     required List<RelationshipMapping> path,
     required List<SearchFilter> filtersOnFirstTable,
     required GeneratedColumn<Object> primaryKeyColumn,
+    bool negate = false,
   }) {
     if (path.isEmpty) {
       throw ArgumentError('Relationship path must not be empty');
@@ -97,8 +98,10 @@ class QueryBuilder {
       if (expr != null) subquery.where(expr);
     }
 
-    // primaryKey IN (subquery)
-    return (primaryKeyColumn as Expression<String>).isInQuery(subquery);
+    // primaryKey IN (subquery) or NOT IN (subquery) when negated
+    final inExpr =
+        (primaryKeyColumn as Expression<String>).isInQuery(subquery);
+    return negate ? inExpr.not() : inExpr;
   }
 
   /// Builds a single `primary_pk IN (SELECT pivot_fk FROM pivot
@@ -367,6 +370,30 @@ class QueryBuilder {
           return (col as GeneratedColumn<String>)
               .isNotIn(list.map((v) => v.toString()).toList());
         }
+      case 'notExists':
+        {
+          // notExists: extract inner values and build IN expression.
+          // The subquery-level negation (NOT IN) is handled by
+          // buildPrimaryKeySubqueryExpression with negate=true.
+          dynamic innerValues;
+          if (filter.value is Map) {
+            innerValues = (filter.value as Map)['values'] ?? filter.value;
+          } else {
+            innerValues = filter.value;
+          }
+          final list = _normalizeToList(innerValues);
+          if (list.isEmpty) return null;
+          if (col is GeneratedColumn<int>) {
+            final ints = list
+                .map((v) => v is int ? v : int.tryParse(v.toString()))
+                .whereType<int>()
+                .toList();
+            if (ints.isEmpty) return null;
+            return col.isIn(ints);
+          }
+          return (col as GeneratedColumn<String>)
+              .isIn(list.map((v) => v.toString()).toList());
+        }
       default:
         throw Exception('Unsupported operator in subquery: ${filter.operator}');
     }
@@ -495,6 +522,16 @@ class QueryBuilder {
           final partClauses = parts.map((_) =>
               '(${cols.map((c) => '($c IS NOT NULL AND $c LIKE ?)').join(' OR ')})');
           return '(${partClauses.join(' AND ')})';
+        case 'notExists':
+          // notExists uses the inner values list for an IN clause.
+          // Subquery-level negation (NOT IN) is handled separately.
+          dynamic innerVal = filter.value;
+          if (innerVal is Map) {
+            innerVal = innerVal['values'] ?? innerVal;
+          }
+          final nValues = _normalizeToList(innerVal);
+          if (nValues.isEmpty) return '1 = 1';
+          return '$column IN (${List.filled(nValues.length, '?').join(', ')})';
         default:
           throw Exception('Unsupported operator: ${filter.operator}');
       }
@@ -564,6 +601,16 @@ class QueryBuilder {
         case 'isNotNull':
         case 'isNull':
         case 'within':
+          break;
+        case 'notExists':
+          dynamic innerVal = filter.value;
+          if (innerVal is Map) {
+            innerVal = innerVal['values'] ?? innerVal;
+          }
+          final nList = _normalizeToList(innerVal);
+          if (nList.isNotEmpty) {
+            args.addAll(nList.map((v) => Variable.withString(v.toString())));
+          }
           break;
         default:
           throw Exception('Unsupported operator: ${filter.operator}');
@@ -780,6 +827,26 @@ class QueryBuilder {
           } else if (col is GeneratedColumn<String>) {
             whereClauses
                 .add(col.isNotIn(list.map((v) => v.toString()).toList()));
+          }
+          break;
+        case 'notExists':
+          // notExists: extract inner values and build IN clause.
+          // Subquery-level negation is handled by buildPrimaryKeySubqueryExpression.
+          dynamic innerVal = filter.value;
+          if (innerVal is Map) {
+            innerVal = innerVal['values'] ?? innerVal;
+          }
+          final neList = _normalizeToList(innerVal);
+          if (neList.isEmpty) break;
+          if (col is GeneratedColumn<int>) {
+            final ints = neList
+                .map((v) => v is int ? v : int.tryParse(v.toString()))
+                .whereType<int>()
+                .toList();
+            if (ints.isNotEmpty) whereClauses.add(col.isIn(ints));
+          } else if (col is GeneratedColumn<String>) {
+            whereClauses
+                .add(col.isIn(neList.map((v) => v.toString()).toList()));
           }
           break;
         default:

--- a/packages/digit_flow_builder/lib/blocs/search_state_manager.dart
+++ b/packages/digit_flow_builder/lib/blocs/search_state_manager.dart
@@ -314,8 +314,13 @@ class SearchStateManager {
         final filters = entry.value['filters'] as List? ?? [];
         for (final filter in filters) {
           if (filter is Map && filter['key'] != null) {
-            // Deduplicate by filter key - later entries override earlier ones
-            filtersByKey[filter['key'].toString()] = filter;
+            // Deduplicate by filter key + operation — allows multiple filters
+            // on the same column with different operations (e.g. 'in' and
+            // 'notExists') to coexist while still deduplicating identical
+            // filters coming from different searchNames.
+            final dedupKey =
+                '${filter['key']}::${filter['operation'] ?? 'equals'}';
+            filtersByKey[dedupKey] = filter;
           }
         }
       }

--- a/packages/digit_flow_builder/lib/utils/function_registry.dart
+++ b/packages/digit_flow_builder/lib/utils/function_registry.dart
@@ -389,21 +389,29 @@ void initializeFunctionRegistry() {
   /// 3. If the `checkStatus` function allows for a new task to be created.
   FunctionRegistry.register('checkEligibilityForAgeAndSideEffect',
       (args, stateData) {
-    if (args.isEmpty) return false;
+    if (args.isEmpty) {
+      return false;
+    }
 
 // --- Resolve DOB ---
     final dobString = args.first?.toString() ?? '';
-    if (dobString.isEmpty) return false;
+    if (dobString.isEmpty) {
+      return false;
+    }
 
     final dob = DigitDateUtils.getFormattedDateToDateTime(dobString);
-    if (dob == null) return false;
+    if (dob == null) {
+      return false;
+    }
 
     final age = DigitDateUtils.calculateAge(dob);
     final totalAgeMonths = age.years * 12 + age.months;
 
 // --- ProjectType comes from FlowBuilderSingleton ---
     final projectType = FlowBuilderSingleton().projectType;
-    if (projectType == null) return false;
+    if (projectType == null) {
+      return false;
+    }
 
 // --- Resolve validMinAge / validMaxAge, fallback to doseCriteria condition ---
     int? minAge = projectType.validMinAge;
@@ -886,7 +894,9 @@ void initializeFunctionRegistry() {
     final standardFn =
         FunctionRegistry.get('checkEligibilityForAgeAndSideEffect');
     final result = standardFn?.call(args, stateData);
-    if (result == true) return true;
+    if (result == true) {
+      return true;
+    }
 
     // If standard check returned false, check if it's due to
     // ADMINISTRATION_FAILED. For Polio, unable-to-deliver should not

--- a/packages/transit_post/lib/blocs/transit_post.dart
+++ b/packages/transit_post/lib/blocs/transit_post.dart
@@ -66,52 +66,52 @@ class TransitPostBloc extends Bloc<TransitPostEvent, TransitPostState> {
     TransitPostDeliveryEvent event,
     TransitPostEmitter emit,
   ) async {
-    try {
-      await userActionLocalRepository.create(UserActionModel(
-          latitude: event.latitude,
-          longitude: event.longitude,
-          locationAccuracy: event.locationAccuracy,
-          tenantId: TransitPostSingleton().tenantId,
-          clientReferenceId: IdGen.instance.identifier,
-          isSync: false,
-          timestamp: DateTime.now().millisecondsSinceEpoch,
-          projectId: TransitPostSingleton().projectId!,
-          boundaryCode: TransitPostSingleton().boundary!.code!,
-          action: 'OTHER',
-          rowVersion: 1,
-          clientAuditDetails: ClientAuditDetails(
-            createdBy: TransitPostSingleton().loggedInUserUuid!,
-            createdTime: DateTime.now().millisecondsSinceEpoch,
-            lastModifiedBy: TransitPostSingleton().loggedInUserUuid,
-            lastModifiedTime: DateTime.now().millisecondsSinceEpoch,
+    await userActionLocalRepository.create(UserActionModel(
+        latitude: event.latitude,
+        longitude: event.longitude,
+        locationAccuracy: event.locationAccuracy,
+        tenantId: TransitPostSingleton().tenantId,
+        clientReferenceId: IdGen.instance.identifier,
+        isSync: false,
+        timestamp: DateTime.now().millisecondsSinceEpoch,
+        projectId: TransitPostSingleton().projectId ?? '',
+        boundaryCode: TransitPostSingleton().boundary?.code ?? '',
+        action: 'OTHER',
+        rowVersion: 1,
+        clientAuditDetails: ClientAuditDetails(
+          createdBy: TransitPostSingleton().loggedInUserUuid!,
+          createdTime: DateTime.now().millisecondsSinceEpoch,
+          lastModifiedBy: TransitPostSingleton().loggedInUserUuid,
+          lastModifiedTime: DateTime.now().millisecondsSinceEpoch,
+        ),
+        auditDetails: AuditDetails(
+          createdBy: TransitPostSingleton().loggedInUserUuid!,
+          createdTime: DateTime.now().millisecondsSinceEpoch,
+          lastModifiedBy: TransitPostSingleton().loggedInUserUuid,
+          lastModifiedTime: DateTime.now().millisecondsSinceEpoch,
+        ),
+        additionalFields: UserActionAdditionalFields(version: 1, fields: [
+          const AdditionalField(
+            'transactionType',
+            'TRANSIT_POST',
           ),
-          auditDetails: AuditDetails(
-            createdBy: TransitPostSingleton().loggedInUserUuid!,
-            createdTime: DateTime.now().millisecondsSinceEpoch,
-            lastModifiedBy: TransitPostSingleton().loggedInUserUuid,
-            lastModifiedTime: DateTime.now().millisecondsSinceEpoch,
+          AdditionalField(
+            'transitPostType',
+            state.transitPostType,
           ),
-          additionalFields: UserActionAdditionalFields(version: 1, fields: [
-            AdditionalField(
-              'transitPostType',
-              state.transitPostType,
-            ),
-            AdditionalField(
-              'transitPostName',
-              state.transitPostName,
-            ),
-            AdditionalField(
-              'scannedResource',
-              event.scannedResource,
-            ),
-          ])));
-      emit(state.copyWith(
-        curCount: state.curCount != null ? state.curCount! + 1 : 1,
-        totalCount: state.totalCount != null ? state.totalCount! + 1 : 1,
-      ));
-    } catch (e) {
-      rethrow;
-    }
+          AdditionalField(
+            'transitPostName',
+            state.transitPostName,
+          ),
+          AdditionalField(
+            'scannedResource',
+            event.scannedResource,
+          ),
+        ])));
+    emit(state.copyWith(
+      curCount: state.curCount != null ? state.curCount! + 1 : 1,
+      totalCount: state.totalCount != null ? state.totalCount! + 1 : 1,
+    ));
   }
 }
 

--- a/packages/transit_post/lib/blocs/transit_post.dart
+++ b/packages/transit_post/lib/blocs/transit_post.dart
@@ -40,16 +40,21 @@ class TransitPostBloc extends Bloc<TransitPostEvent, TransitPostState> {
     ));
   }
 
+  static const _transitPostFilter =
+      '"key":"transactionType","value":"TRANSIT_POST"';
+
   FutureOr<void> _handleDeliveryCount(
     TransitPostDeliveryCountEvent event,
     TransitPostEmitter emit,
   ) async {
     emit(state.copyWith(loading: true));
-    final totalCount = await userActionLocalRepository
-        .fetchCount(TransitPostSingleton().loggedInUserUuid);
+    final totalCount = await userActionLocalRepository.fetchCount(
+        TransitPostSingleton().loggedInUserUuid,
+        additionalFieldsFilter: _transitPostFilter);
 
     final curCount = await userActionLocalRepository.fetchCount(
         TransitPostSingleton().loggedInUserUuid,
+        additionalFieldsFilter: _transitPostFilter,
         query: UserActionSearchModel(
             auditDetails: AuditDetails(
                 createdBy: TransitPostSingleton().loggedInUserUuid!,

--- a/packages/transit_post/lib/data/repositories/local/user_action.dart
+++ b/packages/transit_post/lib/data/repositories/local/user_action.dart
@@ -110,6 +110,10 @@ class UserActionLocalRepository
         conditions.add(sql.userAction.clientCreatedBy.equalsNullable(userId));
       }
 
+      // Filter only TRANSIT_POST records by checking additionalFields JSON
+      conditions.add(sql.userAction.additionalFields
+          .like('%"key":"transactionType","value":"TRANSIT_POST"%'));
+
       if (query?.auditDetails?.createdTime != null) {
         DateTime createdDate;
 

--- a/packages/transit_post/lib/data/repositories/local/user_action.dart
+++ b/packages/transit_post/lib/data/repositories/local/user_action.dart
@@ -97,6 +97,7 @@ class UserActionLocalRepository
   FutureOr<int> fetchCount(
     String? userId, {
     UserActionSearchModel? query,
+    String? additionalFieldsFilter,
   }) async {
     return retryLocalCallOperation<int>(() async {
       final selectQuery = sql.selectOnly(sql.userAction)
@@ -110,9 +111,10 @@ class UserActionLocalRepository
         conditions.add(sql.userAction.clientCreatedBy.equalsNullable(userId));
       }
 
-      // Filter only TRANSIT_POST records by checking additionalFields JSON
-      conditions.add(sql.userAction.additionalFields
-          .like('%"key":"transactionType","value":"TRANSIT_POST"%'));
+      if (additionalFieldsFilter != null) {
+        conditions.add(sql.userAction.additionalFields
+            .like('%$additionalFieldsFilter%'));
+      }
 
       if (query?.auditDetails?.createdTime != null) {
         DateTime createdDate;

--- a/packages/transit_post/lib/pages/transit_post_record_vaccination.dart
+++ b/packages/transit_post/lib/pages/transit_post_record_vaccination.dart
@@ -83,7 +83,14 @@ class TransitPostRecordVaccinationPageState
                       ),
                       onPressed: () {
                         final bloc = context.read<DigitScannerBloc>();
-                        final state = bloc.state.barCodes;
+                        final barCodes = bloc.state.barCodes;
+
+                        final scannedResource = barCodes.isNotEmpty
+                            ? DigitScannerUtils()
+                                .getGs1CodeFormattedStringAtIndex(
+                                    barCodes, 0)
+                                .toString()
+                            : '';
 
                         context.read<TransitPostBloc>().add(
                             TransitPostDeliveryEvent(
@@ -103,9 +110,7 @@ class TransitPostRecordVaccinationPageState
                                     (transitPostState.totalCount == null)
                                         ? 1
                                         : transitPostState.totalCount! + 1,
-                                scannedResource: DigitScannerUtils()
-                                    .getGs1CodeFormattedStringAtIndex(state, 0)
-                                    .toString()));
+                                scannedResource: scannedResource));
                         context.router
                             .push(const TransitPostAcknowledgmentRoute());
                       },
@@ -188,14 +193,12 @@ class TransitPostRecordVaccinationPageState
                         )
                       ]),
                     SizedBox(
-                      height: (tableRow.length * 50.0).toDouble().clamp(
-                              100, MediaQuery.of(context).size.height * 0.5) +
-                          40,
+                      height: tableRow.length * 55.0 + 80,
                       child: DigitTable(
-                          tableHeight: (tableRow.length * 50.0)
-                              .toDouble()
-                              .clamp(100,
-                                  MediaQuery.of(context).size.height * 0.5),
+                          enableBorder: true,
+                          withRowDividers: false,
+                          withColumnDividers: false,
+                          showSelectedState: false,
                           showPagination: false,
                           columns: [
                             DigitTableColumn(
@@ -215,44 +218,53 @@ class TransitPostRecordVaccinationPageState
                     )
                   ]),
                   BlocBuilder<DigitScannerBloc, DigitScannerState>(
-                      builder: (context, scannerState) => DigitCard(
-                              margin: const EdgeInsets.all(spacer2),
-                              children: [
-                                LabelValueSummary(
-                                  heading: localizations.translate(
-                                    i18.transitPost.resourceScannedLabel,
-                                  ),
-                                  items: scannerState.barCodes.isNotEmpty
-                                      ? (DigitScannerUtils()
-                                              .getGs1CodeFormattedStringAtIndex(
-                                                  scannerState.barCodes, 0))
-                                          .entries
-                                          .map((entry) {
-                                          return LabelValueItem(
-                                            labelFlex: 5,
-                                            label: localizations.translate(
-                                              "GS1_${entry.key}",
-                                            ),
-                                            value: entry.value is DateTime
-                                                ? DateFormat('d MMMM yyyy')
-                                                    .format(entry.value)
-                                                    .toString()
-                                                : entry.value,
-                                            maxLines: 5,
-                                          );
-                                        }).toList()
-                                      : [
-                                          LabelValueItem(
-                                            labelFlex: 5,
-                                            label: localizations.translate(
-                                              i18.transitPost.resourceCodeLabel,
-                                            ),
-                                            value: scannerState.qrCodes.first,
-                                            maxLines: 5,
-                                          )
-                                        ],
-                                )
-                              ]))
+                      builder: (context, scannerState) {
+                        final hasBarCodes = scannerState.barCodes.isNotEmpty;
+                        final hasQrCodes = scannerState.qrCodes.isNotEmpty;
+
+                        if (!hasBarCodes && !hasQrCodes) {
+                          return const SizedBox.shrink();
+                        }
+
+                        return DigitCard(
+                            margin: const EdgeInsets.all(spacer2),
+                            children: [
+                              LabelValueSummary(
+                                heading: localizations.translate(
+                                  i18.transitPost.resourceScannedLabel,
+                                ),
+                                items: hasBarCodes
+                                    ? (DigitScannerUtils()
+                                            .getGs1CodeFormattedStringAtIndex(
+                                                scannerState.barCodes, 0))
+                                        .entries
+                                        .map((entry) {
+                                        return LabelValueItem(
+                                          labelFlex: 5,
+                                          label: localizations.translate(
+                                            "GS1_${entry.key}",
+                                          ),
+                                          value: entry.value is DateTime
+                                              ? DateFormat('d MMMM yyyy')
+                                                  .format(entry.value)
+                                                  .toString()
+                                              : entry.value,
+                                          maxLines: 5,
+                                        );
+                                      }).toList()
+                                    : [
+                                        LabelValueItem(
+                                          labelFlex: 5,
+                                          label: localizations.translate(
+                                            i18.transitPost.resourceCodeLabel,
+                                          ),
+                                          value: scannerState.qrCodes.first,
+                                          maxLines: 5,
+                                        )
+                                      ],
+                              )
+                            ]);
+                      })
                 ],
               ));
         },
@@ -266,21 +278,21 @@ class TransitPostRecordVaccinationPageState
     if (resources == null || resources.isEmpty) return [];
 
     List<DigitTableRow> finalTableRow = [];
-    int count = 1;
 
-    for (var resource in resources) {
+    for (var i = 0; i < resources.length; i++) {
+      final resource = resources[i];
       List<DigitTableData> tableData = [];
 
+      // All product variants belong to Dose 1 (single delivery)
       tableData.add(
         DigitTableData(
-            "${localizations.translate(i18.transitPost.doseLabel)} $count",
-            cellKey: "Dose$count"),
+            "${localizations.translate(i18.transitPost.doseLabel)} 1",
+            cellKey: "Dose1_$i"),
       );
-      tableData.add(DigitTableData(resource.productVariantId,
-          cellKey: resource.name ?? resource.productVariantId));
+      tableData.add(DigitTableData(resource.name ?? resource.productVariantId,
+          cellKey: resource.productVariantId));
 
       finalTableRow.add(DigitTableRow(tableRow: tableData));
-      count++;
     }
     return finalTableRow;
   }

--- a/packages/transit_post/lib/pages/transit_post_selection.dart
+++ b/packages/transit_post/lib/pages/transit_post_selection.dart
@@ -96,6 +96,40 @@ class TransitPostSelectionPageState
                         children: [
                           DigitButton(
                             label: localizations.translate(
+                              i18.transitPost.recordDeliveryLabel,
+                            ),
+                            isDisabled: !form.valid,
+                            onPressed: () {
+                              form.markAllAsTouched();
+                              if (!form.valid) return;
+
+                              final transitPostType =
+                                  form.control(_transitPostType).value;
+                              final transitPostName =
+                                  form.control(_transitPostName).value;
+                              final lat = form.control(_latKey).value;
+                              final lng = form.control(_lngKey).value;
+                              final accuracy = form.control(_accuracyKey).value;
+
+                              context
+                                  .read<TransitPostBloc>()
+                                  .add(TransitPostSelectionEvent(
+                                    longitude: lng,
+                                    latitude: lat,
+                                    locationAccuracy: accuracy,
+                                    transitPostName: transitPostName,
+                                    transitPostType: transitPostType,
+                                  ));
+
+                              context.router.push(
+                                  const TransitPostRecordVaccinationRoute());
+                            },
+                            type: DigitButtonType.primary,
+                            size: DigitButtonSize.large,
+                            mainAxisSize: MainAxisSize.max,
+                          ),
+                          DigitButton(
+                            label: localizations.translate(
                               i18.transitPost.scanResourceLabel,
                             ),
                             isDisabled: !form.valid,
@@ -172,7 +206,7 @@ class TransitPostSelectionPageState
                                 }
                               }
                             },
-                            type: DigitButtonType.primary,
+                            type: DigitButtonType.secondary,
                             size: DigitButtonSize.large,
                             mainAxisSize: MainAxisSize.max,
                             prefixIcon: Icons.document_scanner_sharp,


### PR DESCRIPTION
…port, transit post enhancements

- Replace checkEligibilityForAgeAndSideEffect with checkPolioEligibility in Polio config (ADMINISTERED_SUCCESS, NOT_VISITED tags, ACTION_BUTTON)
- Add notExists operation to query_builder and multi_table_filter_resolver for cross-table NOT IN subqueries
- Fix VACCINATION_FAILED filter to require ADMINISTRATION_FAILED with no subsequent VISITED/ADMINISTRATION_SUCCESS tasks
- Fix search_state_manager filter dedup to use composite key (key::operation) allowing dual filters on same field
- Transit post: add Record Delivery button (direct delivery without scanning), change icon to local_shipping
- Transit post: fix null boundary crash in user action creation, set boundary in setPackagesSingleton
- Transit post: add transactionType TRANSIT_POST to additionalFields, filter delivery counts by it
- Transit post: fix table sizing/whitespace, show resource name instead of productVariantId, fix dose labeling
- Hide stock sync card for Polio in home page