### PR TITLE
HCMPRE-901: Fix age eligibility gate for non-range doseCriteria conditions

### DIFF
--- a/apps/health_campaign_field_worker_app/lib/pages/home.dart
+++ b/apps/health_campaign_field_worker_app/lib/pages/home.dart
@@ -56,6 +56,7 @@ import '../sampleJsonConfigs/polio_inside_household_monitoring.dart';
 import '../sampleJsonConfigs/polio_lqa_data_collection.dart';
 import '../sampleJsonConfigs/polio_stock_details.dart';
 import '../sampleJsonConfigs/registration_flows.dart';
+import '../sampleJsonConfigs/registration_smc_flows.dart';
 import '../sampleJsonConfigs/stock_reconciliation.dart';
 import '../utils/attendance_utils.dart';
 import '../utils/date_util_attendance.dart';

--- a/packages/digit_flow_builder/lib/utils/function_registry.dart
+++ b/packages/digit_flow_builder/lib/utils/function_registry.dart
@@ -1,5 +1,6 @@
 import 'package:collection/collection.dart';
 import 'package:digit_data_model/data_model.dart';
+import 'package:digit_formula_parser/digit_formula_parser.dart';
 import 'package:digit_data_model/models/entities/attendance_log.dart';
 import 'package:digit_flow_builder/blocs/flow_crud_bloc.dart';
 import 'package:digit_flow_builder/utils/utils.dart';
@@ -416,30 +417,39 @@ void initializeFunctionRegistry() {
 // --- Resolve validMinAge / validMaxAge, fallback to doseCriteria condition ---
     int? minAge = projectType.validMinAge;
     int? maxAge = projectType.validMaxAge;
+    // When explicit age bounds are not configured, evaluate each
+    // doseCriteria condition individually against the beneficiary's age.
+    // Beneficiary passes the age gate if ANY condition matches.
+    bool? ageEligibleByCondition;
     if (minAge == null || maxAge == null) {
+      ageEligibleByCondition = false;
       for (final cycle in projectType.cycles ?? []) {
         if ((cycle.startDate ?? 0) < DateTime.now().millisecondsSinceEpoch &&
             (cycle.endDate ?? 0) > DateTime.now().millisecondsSinceEpoch) {
           for (final delivery in cycle.deliveries ?? []) {
             for (final dc in delivery.doseCriteria ?? []) {
               final condition = dc.condition ?? '';
-              final match =
-                  RegExp(r'(\d+)<=ageandage<=(\d+)').firstMatch(condition);
-              if (match != null) {
-                final parsedMin = int.tryParse(match.group(1) ?? '');
-                final parsedMax = int.tryParse(match.group(2) ?? '');
-                if (parsedMin != null) {
-                  minAge = (minAge == null || parsedMin < minAge!)
-                      ? parsedMin
-                      : minAge;
+              if (condition.isEmpty) {
+                ageEligibleByCondition = true;
+                break;
+              }
+              try {
+                final sanitizedCondition = condition
+                    .replaceAll(' and ', ' && ')
+                    .replaceAll('and', '&&');
+                final parser = FormulaParser(
+                    sanitizedCondition, {'age': totalAgeMonths});
+                final result = parser.parse;
+                if (result['isSuccess'] == true &&
+                    result['value'] == true) {
+                  ageEligibleByCondition = true;
+                  break;
                 }
-                if (parsedMax != null) {
-                  maxAge = (maxAge == null || parsedMax > maxAge!)
-                      ? parsedMax
-                      : maxAge;
-                }
+              } catch (e) {
+                debugPrint('Age condition evaluation error: $e');
               }
             }
+            if (ageEligibleByCondition == true) break;
           }
           break;
         }
@@ -467,10 +477,9 @@ void initializeFunctionRegistry() {
     }
 
 // --- Check age eligibility ---
-    final isWithinAge = minAge != null &&
-        maxAge != null &&
-        totalAgeMonths >= minAge &&
-        totalAgeMonths <= maxAge;
+    final isWithinAge = (minAge != null && maxAge != null)
+        ? (totalAgeMonths >= minAge && totalAgeMonths <= maxAge)
+        : (ageEligibleByCondition ?? false);
 
     if (!isWithinAge) {
       return false;
@@ -552,10 +561,9 @@ void initializeFunctionRegistry() {
           (lastTaskTime >= (currentCycle['startDate'] ?? 0) &&
               lastTaskTime <= (currentCycle['endDate'] ?? 0));
 
-      final isWithinAge2 = minAge != null &&
-          maxAge != null &&
-          totalAgeMonths >= minAge &&
-          totalAgeMonths <= maxAge;
+      final isWithinAge2 = (minAge != null && maxAge != null)
+          ? (totalAgeMonths >= minAge && totalAgeMonths <= maxAge)
+          : (ageEligibleByCondition ?? false);
 
       if (!isWithinAge2) {
         return false;
@@ -569,7 +577,7 @@ void initializeFunctionRegistry() {
       if (minAge != null && maxAge != null) {
         return totalAgeMonths >= minAge && totalAgeMonths <= maxAge;
       }
-      return true;
+      return ageEligibleByCondition ?? true;
     }
   });
 


### PR DESCRIPTION
## Summary
- When `validMinAge`/`validMaxAge` are not configured on the project type, the eligibility fallback used a regex that only matched range patterns like `6<=ageandage<=59`, ignoring conditions like `age>=6`.
- A 5-year-old (60 months) was incorrectly marked **ineligible** because `60 > 59` (the max extracted from the range condition), even though `age>=6` should have made them eligible for AZM delivery.
- Replaced the regex-based fallback with `FormulaParser`-based evaluation of each doseCriteria condition individually. Beneficiary now passes the age gate if **any** condition evaluates to true.

## Changes
- `packages/digit_flow_builder/lib/utils/function_registry.dart` — Replaced regex fallback in `checkEligibilityForAgeAndSideEffect` with per-condition FormulaParser evaluation; updated all three age check sites.
- `apps/health_campaign_field_worker_app/lib/pages/home.dart` — Added SMC flows import.

## Observation (PM)
When `validMinAge` and `validMaxAge` are not configured, an open-ended condition like `age>=6` will pass for any beneficiary older than 6 months — including those with incorrectly entered ages (e.g., 150 or 200 years). It is recommended to always configure a `validMaxAge` or include a range-bound condition to prevent delivery to erroneously aged beneficiaries.

## Test plan
- [ ] Register a beneficiary aged **5 years** → should show **AZM** (PVAR-2026-07-01-001389) and NOT show ineligible tag
- [ ] Register a beneficiary aged **8 months** → should show **both VAS and AZM**
- [ ] Register a beneficiary aged **3 months** → should show **ineligible** tag (below 6 months)
- [ ] Verify campaigns with explicit `validMinAge`/`validMaxAge` still work as before