### PR TITLE
HCMPRE-6001: Remove MDMS v1 translation layer, use v2 API natively

### DIFF
--- a/apps/health_campaign_field_worker_app/lib/blocs/app_initialization/app_initialization.dart
+++ b/apps/health_campaign_field_worker_app/lib/blocs/app_initialization/app_initialization.dart
@@ -12,11 +12,9 @@ import 'package:recase/recase.dart';
 import '../../data/local_store/no_sql/schema/app_configuration.dart';
 import '../../data/local_store/no_sql/schema/service_registry.dart';
 import '../../data/repositories/remote/mdms.dart';
-import '../../models/app_config/app_config_model.dart';
 import '../../models/entities/mdms_master_enums.dart';
 import '../../models/entities/mdms_module_enums.dart';
 import '../../utils/environment_config.dart';
-import '../../utils/utils.dart';
 import '../../widgets/network_manager_provider_wrapper.dart';
 
 part 'app_initialization.freezed.dart';
@@ -62,94 +60,19 @@ class AppInitializationBloc
       try {
         final result = await mdmsRepository.searchServiceRegistry(
           envConfig.variables.mdmsApiPath,
-          MdmsRequestModel(
-            mdmsCriteria: MdmsCriteriaModel(
-              tenantId: envConfig.variables.tenantId,
-              moduleDetails: [
-                const MdmsModuleDetailModel(
-                  moduleName: 'HCM-SERVICE-REGISTRY',
-                  masterDetails: [
-                    MdmsMasterDetailModel('serviceRegistry'),
-                  ],
-                ),
-              ],
-            ),
-          ).toJson(),
+          envConfig.variables.tenantId,
         );
         await mdmsRepository.writeToRegistryDB(result, isar);
 
         final configResult = await mdmsRepository.searchAppConfig(
           envConfig.variables.mdmsApiPath,
-          MdmsRequestModel(
-            mdmsCriteria: MdmsCriteriaModel(
-              tenantId: envConfig.variables.tenantId,
-              moduleDetails: [
-                MdmsModuleDetailModel(
-                  moduleName: ModuleEnums.hcm.toValue(),
-                  masterDetails: getMasterDetailsModel([
-                    MasterEnums.appConfig.toValue(),
-                    MasterEnums.symptomTypes.toValue(),
-                    MasterEnums.referralReasons.toValue(),
-                    MasterEnums.manualAttendanceReasons.toValue(),
-                    MasterEnums.houseStructureTypes.toValue(),
-                    MasterEnums.refusalReasons.toValue(),
-                    MasterEnums.bandWidthBatchSize.toValue(),
-                    MasterEnums.beneficiaryIdConfig.toValue(),
-                    MasterEnums.downSyncBandwidthBatchSize.toValue(),
-                    MasterEnums.hhDelReasons.toValue(),
-                    MasterEnums.hhMemberDelReasons.toValue(),
-                    MasterEnums.backgroundServiceConfig.toValue(),
-                    MasterEnums.checklistTypes.toValue(),
-                    MasterEnums.idTypes.toValue(),
-                    MasterEnums.relationShipTypeOptions.toValue(),
-                    MasterEnums.deliveryComments.toValue(),
-                    MasterEnums.backendInterface.toValue(),
-                    MasterEnums.callSupport.toValue(),
-                    MasterEnums.transportTypes.toValue(),
-                    MasterEnums.firebaseConfig.toValue(),
-                    MasterEnums.searchHouseHoldFilters.toValue(),
-                    MasterEnums.transitPostType.toValue(),
-                    MasterEnums.searchCLFFilters.toValue(),
-                    MasterEnums.boundaryRelationShip.toValue(),
-                    MasterEnums.deviceChangeReasons.toValue(),
-                    MasterEnums.singleUserLogin.toValue(),
-                  ]),
-                ),
-                MdmsModuleDetailModel(
-                  moduleName: ModuleEnums.commonMasters.toValue(),
-                  masterDetails: getMasterDetailsModel([
-                    MasterEnums.stateInfo.toValue(),
-                    MasterEnums.genderType.toValue(),
-                    MasterEnums.privacyPolicy.toValue(),
-                  ]),
-                ),
-                MdmsModuleDetailModel(
-                  moduleName: ModuleEnums.moduleVersion.toValue(),
-                  masterDetails:
-                      getMasterDetailsModel([MasterEnums.rowVersion.toValue()]),
-                ),
-              ],
-            ),
-          ).toJson(),
+          envConfig.variables.tenantId,
         );
 
         final pgrServiceDefinitions =
             await mdmsRepository.searchPGRServiceDefinitions(
           envConfig.variables.mdmsApiPath,
-          MdmsRequestModel(
-            mdmsCriteria: MdmsCriteriaModel(
-              tenantId: envConfig.variables.tenantId,
-              moduleDetails: [
-                MdmsModuleDetailModel(
-                  moduleName: ModuleEnums.rainmakerPgr.toValue(),
-                  masterDetails: [
-                    MdmsMasterDetailModel(
-                        MasterEnums.serviceDefinitions.toValue()),
-                  ],
-                ),
-              ],
-            ),
-          ).toJson(),
+          envConfig.variables.tenantId,
         );
 
         await mdmsRepository.writeToAppConfigDB(
@@ -158,29 +81,14 @@ class AppInitializationBloc
           isar,
         );
         try {
-          final dashboardMdmsRes = await mdmsRepository.searchMDMS(
+          final dashboardDataList = await mdmsRepository.searchMDMS(
             envConfig.variables.mdmsApiPath,
-            MdmsRequestModel(
-              mdmsCriteria: MdmsCriteriaModel(
-                tenantId: envConfig.variables.tenantId,
-                moduleDetails: [
-                  MdmsModuleDetailModel(
-                    moduleName: ModuleEnums.hcm.toValue(),
-                    masterDetails: [
-                      MdmsMasterDetailModel(
-                        MasterEnums.dashboardConfig.toValue(),
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-            ).toJson(),
+            tenantId: envConfig.variables.tenantId,
+            schemaCode: '${ModuleEnums.hcm.toValue()}.${MasterEnums.dashboardConfig.toValue()}',
           );
-          final hcmModule =
-              dashboardMdmsRes?[ModuleEnums.hcm.toValue().toString()];
-          if (hcmModule != null) {
+          if (dashboardDataList.isNotEmpty) {
             final dashboardConfigs = DashboardConfigPrimaryWrapper.fromJson(
-              Map<String, dynamic>.from(hcmModule),
+              {MasterEnums.dashboardConfig.toValue(): dashboardDataList},
             ).dashboardConfigWrapper;
 
             if (dashboardConfigs.isNotEmpty) {

--- a/apps/health_campaign_field_worker_app/lib/blocs/app_initialization/app_initialization.dart
+++ b/apps/health_campaign_field_worker_app/lib/blocs/app_initialization/app_initialization.dart
@@ -87,8 +87,9 @@ class AppInitializationBloc
             schemaCode: '${ModuleEnums.hcm.toValue()}.${MasterEnums.dashboardConfig.toValue()}',
           );
           if (dashboardDataList.isNotEmpty) {
+            final String dashboardKey = MasterEnums.dashboardConfig.toValue() as String;
             final dashboardConfigs = DashboardConfigPrimaryWrapper.fromJson(
-              {MasterEnums.dashboardConfig.toValue(): dashboardDataList},
+              {dashboardKey: dashboardDataList},
             ).dashboardConfigWrapper;
 
             if (dashboardConfigs.isNotEmpty) {

--- a/apps/health_campaign_field_worker_app/lib/blocs/project/project.dart
+++ b/apps/health_campaign_field_worker_app/lib/blocs/project/project.dart
@@ -29,7 +29,8 @@ import '../../data/local_store/no_sql/schema/service_registry.dart';
 import '../../data/local_store/secure_store/secure_store.dart';
 import '../../data/repositories/remote/bandwidth_check.dart';
 import '../../data/repositories/remote/mdms.dart';
-import '../../models/app_config/app_config_model.dart';
+import '../../models/entities/mdms_master_enums.dart';
+import '../../models/entities/mdms_module_enums.dart';
 import '../../models/auth/auth_model.dart';
 import '../../models/downsync/downsync.dart';
 import '../../models/entities/roles_type.dart';
@@ -306,17 +307,7 @@ class ProjectBloc extends Bloc<ProjectEvent, ProjectState> {
       try {
         final projectTypes = await mdmsRepository.searchProjectType(
           envConfig.variables.mdmsApiPath,
-          MdmsRequestModel(
-            mdmsCriteria: MdmsCriteriaModel(
-              tenantId: envConfig.variables.tenantId,
-              moduleDetails: [
-                const MdmsModuleDetailModel(
-                  moduleName: 'HCM-PROJECT-TYPES',
-                  masterDetails: [MdmsMasterDetailModel('projectTypes')],
-                ),
-              ],
-            ),
-          ).toJson(),
+          envConfig.variables.tenantId,
         );
 
         await mdmsRepository.writeToProjectTypeDB(
@@ -725,28 +716,12 @@ class ProjectBloc extends Bloc<ProjectEvent, ProjectState> {
       }
 
       try {
-        final formConfigResult = await mdmsRepository.searchMDMS(
+        final formConfigs = await mdmsRepository.searchMDMS(
           envConfig.variables.mdmsApiPath,
-          MdmsRequestModel(
-            mdmsCriteria: MdmsCriteriaModel(
-              tenantId: envConfig.variables.tenantId,
-              moduleDetails: [
-                MdmsModuleDetailModel(
-                  moduleName: 'HCM-ADMIN-CONSOLE',
-                  masterDetails: [
-                    MdmsMasterDetailModel(
-                      'FormConfig',
-                      filter:
-                          "[?(@.project=='${event.model.referenceID}' && @.isSelected==true)]",
-                    ),
-                  ],
-                ),
-              ],
-            ),
-          ).toJson(),
+          tenantId: envConfig.variables.tenantId,
+          schemaCode: '${ModuleEnums.hcmAdminConsole.toValue()}.${MasterEnums.formConfig.toValue()}',
+          filters: {'project': event.model.referenceID},
         );
-
-        final formConfigs = formConfigResult['HCM-ADMIN-CONSOLE']['FormConfig'];
 
         for (final config in formConfigs) {
           await enrichFormSchemasWithEnumsForForms(config);
@@ -765,36 +740,14 @@ class ProjectBloc extends Bloc<ProjectEvent, ProjectState> {
         return;
       }
 
-      final configResult = await mdmsRepository.searchAppConfig(
+      final configResult = await mdmsRepository.searchRowVersions(
         envConfig.variables.mdmsApiPath,
-        MdmsRequestModel(
-          mdmsCriteria: MdmsCriteriaModel(
-            tenantId: envConfig.variables.tenantId,
-            moduleDetails: [
-              const MdmsModuleDetailModel(
-                moduleName: 'module-version',
-                masterDetails: [
-                  MdmsMasterDetailModel('ROW_VERSIONS'),
-                ],
-              ),
-            ],
-          ),
-        ).toJson(),
+        envConfig.variables.tenantId,
       );
 
       final projectType = await mdmsRepository.searchProjectType(
         envConfig.variables.mdmsApiPath,
-        MdmsRequestModel(
-          mdmsCriteria: MdmsCriteriaModel(
-            tenantId: envConfig.variables.tenantId,
-            moduleDetails: [
-              const MdmsModuleDetailModel(
-                moduleName: 'HCM-PROJECT-TYPES',
-                masterDetails: [MdmsMasterDetailModel('projectTypes')],
-              ),
-            ],
-          ),
-        ).toJson(),
+        envConfig.variables.tenantId,
       );
 
       await mdmsRepository.writeToProjectTypeDB(
@@ -1397,8 +1350,8 @@ class ProjectBloc extends Bloc<ProjectEvent, ProjectState> {
       return;
     }
 
-    // Collect all module.master pairs across all form pages
-    final Map<String, Set<String>> moduleToMasters = {};
+    // Collect all unique schemaCodes across all form pages
+    final Set<String> schemaCodes = {};
 
     for (final formConfig in formTypeConfigs) {
       final pages = formConfig['pages'] ?? [];
@@ -1409,42 +1362,31 @@ class ProjectBloc extends Bloc<ProjectEvent, ProjectState> {
           if (schemaCode != null && schemaCode.toString().isNotEmpty) {
             final parts = schemaCode.split('.');
             if (parts.length == 2) {
-              final module = parts[0];
-              final master = parts[1];
-              moduleToMasters.putIfAbsent(module, () => <String>{}).add(master);
+              schemaCodes.add(schemaCode);
             }
           }
         }
       }
     }
 
-    // ✅ If no schemaCode found, just store as-is
-    if (moduleToMasters.isEmpty) {
+    // If no schemaCode found, just store as-is
+    if (schemaCodes.isEmpty) {
       await storeSchema(formConfigs);
       return;
     }
 
-    // Prepare module details for MDMS request
-    final moduleDetails = moduleToMasters.entries.map((entry) {
-      return MdmsModuleDetailModel(
-        moduleName: entry.key,
-        masterDetails:
-            entry.value.map((m) => MdmsMasterDetailModel(m)).toList(),
+    // Fetch enum data per schemaCode via v2 calls
+    final Map<String, List<dynamic>> enumsBySchemaCode = {};
+    for (final schemaCode in schemaCodes) {
+      final dataList = await mdmsRepository.searchMDMS(
+        envConfig.variables.mdmsApiPath,
+        tenantId: envConfig.variables.tenantId,
+        schemaCode: schemaCode,
       );
-    }).toList();
+      enumsBySchemaCode[schemaCode] = dataList;
+    }
 
-    // Fetch all master data in a single MDMS call
-    final mdmsResponse = await mdmsRepository.searchMDMS(
-      envConfig.variables.mdmsApiPath,
-      MdmsRequestModel(
-        mdmsCriteria: MdmsCriteriaModel(
-          tenantId: envConfig.variables.tenantId,
-          moduleDetails: moduleDetails,
-        ),
-      ).toJson(),
-    );
-
-    // ✅ Now enrich all FORM screens with enums
+    // Now enrich all FORM screens with enums
     for (final formConfig in formTypeConfigs) {
       final pages = formConfig['pages'] ?? [];
       for (final page in pages) {
@@ -1452,27 +1394,22 @@ class ProjectBloc extends Bloc<ProjectEvent, ProjectState> {
         for (final property in properties) {
           final schemaCode = property['schemaCode'];
           if (schemaCode != null && schemaCode.toString().isNotEmpty) {
-            final parts = schemaCode.split('.');
-            if (parts.length == 2) {
-              final module = parts[0];
-              final master = parts[1];
-              final enumValues = mdmsResponse[module]?[master];
+            final enumValues = enumsBySchemaCode[schemaCode];
 
-              if (enumValues != null) {
-                property['enums'] = enumValues
-                    .map((e) => {
-                          'code': e['code'],
-                          'name': e['name'] ?? e['code'],
-                        })
-                    .toList();
-              }
+            if (enumValues != null) {
+              property['enums'] = enumValues
+                  .map((e) => {
+                        'code': e['code'],
+                        'name': e['name'] ?? e['code'],
+                      })
+                  .toList();
             }
           }
         }
       }
     }
 
-    // ✅ Finally, store the full formConfigs (including updated FORM ones)
+    // Finally, store the full formConfigs (including updated FORM ones)
     await storeSchema(formConfigs);
   }
 

--- a/apps/health_campaign_field_worker_app/lib/data/repositories/remote/mdms.dart
+++ b/apps/health_campaign_field_worker_app/lib/data/repositories/remote/mdms.dart
@@ -61,8 +61,8 @@ class MdmsRepository {
     String tenantId,
   ) async {
     try {
-      final module = ModuleEnums.serviceRegistry.toValue();
-      final master = MasterEnums.serviceRegistryMaster.toValue();
+      final String module = ModuleEnums.serviceRegistry.toValue() as String;
+      final String master = MasterEnums.serviceRegistryMaster.toValue() as String;
 
       final dataList = await _searchV2(
         apiEndPoint,
@@ -195,8 +195,8 @@ class MdmsRepository {
     String tenantId,
   ) async {
     try {
-      final module = ModuleEnums.rainmakerPgr.toValue();
-      final master = MasterEnums.serviceDefinitions.toValue();
+      final String module = ModuleEnums.rainmakerPgr.toValue() as String;
+      final String master = MasterEnums.serviceDefinitions.toValue() as String;
 
       final dataList = await _searchV2(
         apiEndPoint,
@@ -224,8 +224,8 @@ class MdmsRepository {
     String tenantId,
   ) async {
     try {
-      final module = ModuleEnums.hcmProjectTypes.toValue();
-      final master = MasterEnums.projectTypes.toValue();
+      final String module = ModuleEnums.hcmProjectTypes.toValue() as String;
+      final String master = MasterEnums.projectTypes.toValue() as String;
 
       final dataList = await _searchV2(
         apiEndPoint,
@@ -277,8 +277,8 @@ class MdmsRepository {
     String tenantId,
   ) async {
     try {
-      final module = ModuleEnums.moduleVersion.toValue();
-      final master = MasterEnums.rowVersion.toValue();
+      final String module = ModuleEnums.moduleVersion.toValue() as String;
+      final String master = MasterEnums.rowVersion.toValue() as String;
 
       final dataList = await _searchV2(
         apiEndPoint,

--- a/apps/health_campaign_field_worker_app/lib/data/repositories/remote/mdms.dart
+++ b/apps/health_campaign_field_worker_app/lib/data/repositories/remote/mdms.dart
@@ -8,6 +8,8 @@ import 'package:dio/dio.dart';
 import 'package:isar/isar.dart';
 
 import '../../../models/app_config/app_config_model.dart' as app_configuration;
+import '../../../models/entities/mdms_master_enums.dart';
+import '../../../models/entities/mdms_module_enums.dart';
 import '../../../models/mdms/service_registry/pgr_service_defenitions.dart';
 import '../../../models/mdms/service_registry/service_registry_model.dart';
 import '../../../models/role_actions/role_actions_model.dart';
@@ -19,112 +21,60 @@ import '../../local_store/no_sql/schema/service_registry.dart';
 class MdmsRepository {
   final Dio _client;
 
-  static const int _v2SearchLimit = 2000;
-
   const MdmsRepository(this._client);
 
-  /// Translates a v1-style MDMS request body (`MdmsCriteria.moduleDetails`)
-  /// into MDMS v2 `_search` calls — one per `module.master` schemaCode —
-  /// and reassembles the flat v2 `mdms` list back into the nested
-  /// `MdmsRes` shape (`{module: {master: [data]}}`) that all existing
-  /// consumers of this repository parse.
-  Future<Map<String, dynamic>> _searchMdmsResV2(
-    String apiEndPoint,
-    Map<String, dynamic> body,
-  ) async {
-    // Normalize: freezed `toJson` may keep nested models as objects.
-    final Map<String, dynamic> normalizedBody =
-        json.decode(json.encode(body)) as Map<String, dynamic>;
-    final criteria =
-        normalizedBody['MdmsCriteria'] as Map<String, dynamic>? ?? {};
-    final tenantId = criteria['tenantId'];
-    final moduleDetails = criteria['moduleDetails'] as List? ?? [];
+  /// Core v2 search method. Makes a single POST call to the MDMS v2
+  /// `_search` endpoint and returns the list of `data` objects from the
+  /// response `mdms` array (only active records).
+  Future<List<dynamic>> _searchV2(
+    String apiEndPoint, {
+    required String tenantId,
+    required String schemaCode,
+    Map<String, dynamic>? filters,
+    int limit = 5000,
+  }) async {
+    final response = await _client.post(apiEndPoint, data: {
+      'MdmsCriteria': {
+        'tenantId': tenantId,
+        'schemaCode': schemaCode,
+        if (filters != null) 'filters': filters,
+        'limit': limit,
+        'isActive': true,
+      },
+    });
 
-    final Map<String, dynamic> mdmsRes = {};
+    final responseData = response.data is String
+        ? json.decode(response.data as String)
+        : response.data;
+    final mdmsList = responseData is List
+        ? responseData
+        : (responseData?['mdms'] as List? ?? []);
 
-    for (final module in moduleDetails) {
-      final moduleName = module['moduleName'] as String;
-      final masterDetails = module['masterDetails'] as List? ?? [];
-
-      for (final master in masterDetails) {
-        final masterName = master['name'] as String;
-
-        final response = await _client.post(apiEndPoint, data: {
-          'MdmsCriteria': {
-            'tenantId': tenantId,
-            'schemaCode': '$moduleName.$masterName',
-            'limit': _v2SearchLimit,
-          },
-        });
-
-        final responseData = response.data is String
-            ? json.decode(response.data as String)
-            : response.data;
-        final mdmsList = responseData is List
-            ? responseData
-            : (responseData?['mdms'] as List? ?? []);
-
-        List<dynamic> dataList = mdmsList
-            .where((e) => e is Map && e['isActive'] != false)
-            .map((e) => e['data'])
-            .toList();
-
-        final filter = master['filter'] as String?;
-        if (filter != null && filter.trim().isNotEmpty) {
-          dataList = _applyV1Filter(dataList, filter);
-        }
-
-        if (dataList.isEmpty) {
-          // No records for this schemaCode on the v2 server — usually a
-          // master that is not registered or whose name/casing differs.
-          // Surfaced here so the missing schemaCode is obvious in the logs.
-          AppLogger.instance.error(
-            title: 'MDMS v2',
-            message: 'Empty result for schemaCode "$moduleName.$masterName"',
-          );
-        }
-
-        final moduleMap = mdmsRes.putIfAbsent(
-          moduleName,
-          () => <String, dynamic>{},
-        ) as Map<String, dynamic>;
-        moduleMap[masterName] = dataList;
-      }
-    }
-
-    return mdmsRes;
-  }
-
-  /// Applies a v1 JSONPath-style filter like
-  /// `[?(@.project=='X' && @.isSelected==true)]` client-side, since
-  /// MDMS v2 does not accept JSONPath filters in the search criteria.
-  /// Supports `&&`-combined equality conditions only.
-  List<dynamic> _applyV1Filter(List<dynamic> data, String filter) {
-    final conditions =
-        RegExp(r"@\.(\w+)\s*==\s*(?:'([^']*)'|(true|false)|([\d.]+))")
-            .allMatches(filter)
-            .toList();
-    if (conditions.isEmpty) return data;
-
-    return data.where((item) {
-      if (item is! Map) return false;
-      for (final m in conditions) {
-        final key = m.group(1);
-        final expected = m.group(2) ?? m.group(3) ?? m.group(4);
-        if (item[key]?.toString() != expected) return false;
-      }
-      return true;
-    }).toList();
+    return mdmsList
+        .where((e) => e is Map && e['isActive'] != false)
+        .map((e) => e['data'])
+        .toList();
   }
 
   Future<ServiceRegistryPrimaryWrapperModel> searchServiceRegistry(
     String apiEndPoint,
-    Map<String, dynamic> body,
+    String tenantId,
   ) async {
     try {
-      final mdmsRes = await _searchMdmsResV2(apiEndPoint, body);
+      final module = ModuleEnums.serviceRegistry.toValue();
+      final master = MasterEnums.serviceRegistryMaster.toValue();
 
-      return ServiceRegistryPrimaryWrapperModel.fromJson(mdmsRes);
+      final dataList = await _searchV2(
+        apiEndPoint,
+        tenantId: tenantId,
+        schemaCode: '$module.$master',
+      );
+
+      return ServiceRegistryPrimaryWrapperModel.fromJson({
+        module: {
+          master: dataList,
+        },
+      });
     } catch (_) {
       rethrow;
     }
@@ -164,20 +114,72 @@ class MdmsRepository {
     });
   }
 
+  /// Fetches app configuration by making individual v2 calls per schemaCode
+  /// and assembling the nested map that AppConfigPrimaryWrapperModel expects.
   Future<app_configuration.AppConfigPrimaryWrapperModel> searchAppConfig(
     String apiEndPoint,
-    Map body,
+    String tenantId,
   ) async {
     try {
-      final mdmsRes = await _searchMdmsResV2(
-        apiEndPoint,
-        Map<String, dynamic>.from(body),
-      );
+      // Define all module.master pairs needed for app config using enums
+      final schemaCodes = <String, List<String>>{
+        ModuleEnums.hcm.toValue(): [
+          MasterEnums.appConfig.toValue(),
+          MasterEnums.symptomTypes.toValue(),
+          MasterEnums.referralReasons.toValue(),
+          MasterEnums.manualAttendanceReasons.toValue(),
+          MasterEnums.houseStructureTypes.toValue(),
+          MasterEnums.refusalReasons.toValue(),
+          MasterEnums.bandWidthBatchSize.toValue(),
+          MasterEnums.beneficiaryIdConfig.toValue(),
+          MasterEnums.downSyncBandwidthBatchSize.toValue(),
+          MasterEnums.hhDelReasons.toValue(),
+          MasterEnums.hhMemberDelReasons.toValue(),
+          MasterEnums.backgroundServiceConfig.toValue(),
+          MasterEnums.checklistTypes.toValue(),
+          MasterEnums.idTypes.toValue(),
+          MasterEnums.relationShipTypeOptions.toValue(),
+          MasterEnums.deliveryComments.toValue(),
+          MasterEnums.backendInterface.toValue(),
+          MasterEnums.callSupport.toValue(),
+          MasterEnums.transportTypes.toValue(),
+          MasterEnums.firebaseConfig.toValue(),
+          MasterEnums.searchHouseHoldFilters.toValue(),
+          MasterEnums.transitPostType.toValue(),
+          MasterEnums.searchCLFFilters.toValue(),
+          MasterEnums.boundaryRelationShip.toValue(),
+          MasterEnums.deviceChangeReasons.toValue(),
+          MasterEnums.singleUserLogin.toValue(),
+        ],
+        ModuleEnums.commonMasters.toValue(): [
+          MasterEnums.stateInfo.toValue(),
+          MasterEnums.genderType.toValue(),
+          MasterEnums.privacyPolicy.toValue(),
+        ],
+        ModuleEnums.moduleVersion.toValue(): [
+          MasterEnums.rowVersion.toValue(),
+        ],
+      };
 
-      final appCon =
-          app_configuration.AppConfigPrimaryWrapperModel.fromJson(mdmsRes);
+      final Map<String, dynamic> mdmsRes = {};
 
-      return appCon;
+      for (final entry in schemaCodes.entries) {
+        final moduleName = entry.key;
+        final moduleMap =
+            mdmsRes.putIfAbsent(moduleName, () => <String, dynamic>{})
+                as Map<String, dynamic>;
+
+        for (final masterName in entry.value) {
+          final dataList = await _searchV2(
+            apiEndPoint,
+            tenantId: tenantId,
+            schemaCode: '$moduleName.$masterName',
+          );
+          moduleMap[masterName] = dataList;
+        }
+      }
+
+      return app_configuration.AppConfigPrimaryWrapperModel.fromJson(mdmsRes);
     } on DioError catch (e) {
       AppLogger.instance.error(
         title: 'MDMS Repository',
@@ -190,12 +192,23 @@ class MdmsRepository {
 
   Future<PGRServiceDefinitions> searchPGRServiceDefinitions(
     String apiEndPoint,
-    Map<String, dynamic> body,
+    String tenantId,
   ) async {
     try {
-      final mdmsRes = await _searchMdmsResV2(apiEndPoint, body);
+      final module = ModuleEnums.rainmakerPgr.toValue();
+      final master = MasterEnums.serviceDefinitions.toValue();
 
-      return PGRServiceDefinitions.fromJson(mdmsRes);
+      final dataList = await _searchV2(
+        apiEndPoint,
+        tenantId: tenantId,
+        schemaCode: '$module.$master',
+      );
+
+      return PGRServiceDefinitions.fromJson({
+        module: {
+          master: dataList,
+        },
+      });
     } on DioError catch (e) {
       AppLogger.instance.error(
         title: 'MDMS Repository',
@@ -208,23 +221,76 @@ class MdmsRepository {
 
   Future<ProjectTypePrimaryWrapper> searchProjectType(
     String apiEndPoint,
-    Map<String, dynamic> body,
+    String tenantId,
   ) async {
     try {
-      final mdmsRes = await _searchMdmsResV2(apiEndPoint, body);
+      final module = ModuleEnums.hcmProjectTypes.toValue();
+      final master = MasterEnums.projectTypes.toValue();
 
-      return ProjectTypePrimaryWrapper.fromJson(mdmsRes);
+      final dataList = await _searchV2(
+        apiEndPoint,
+        tenantId: tenantId,
+        schemaCode: '$module.$master',
+      );
+
+      return ProjectTypePrimaryWrapper.fromJson({
+        module: {
+          master: dataList,
+        },
+      });
     } catch (_) {
       rethrow;
     }
   }
 
-  Future<dynamic> searchMDMS(
+  /// Generic v2 search that returns `List<dynamic>` of data objects directly.
+  /// Used for FormConfig, dashboard config, enum values, and other ad-hoc
+  /// MDMS lookups.
+  Future<List<dynamic>> searchMDMS(
+    String apiEndPoint, {
+    required String tenantId,
+    required String schemaCode,
+    Map<String, dynamic>? filters,
+    int limit = 5000,
+  }) async {
+    try {
+      return await _searchV2(
+        apiEndPoint,
+        tenantId: tenantId,
+        schemaCode: schemaCode,
+        filters: filters,
+        limit: limit,
+      );
+    } on DioError catch (e) {
+      AppLogger.instance.error(
+        title: 'MDMS Repository',
+        message: '$e',
+        stackTrace: e.stackTrace,
+      );
+      rethrow;
+    }
+  }
+
+  /// Fetches row versions only (subset of app config).
+  Future<app_configuration.AppConfigPrimaryWrapperModel> searchRowVersions(
     String apiEndPoint,
-    Map<String, dynamic> body,
+    String tenantId,
   ) async {
     try {
-      return await _searchMdmsResV2(apiEndPoint, body);
+      final module = ModuleEnums.moduleVersion.toValue();
+      final master = MasterEnums.rowVersion.toValue();
+
+      final dataList = await _searchV2(
+        apiEndPoint,
+        tenantId: tenantId,
+        schemaCode: '$module.$master',
+      );
+
+      return app_configuration.AppConfigPrimaryWrapperModel.fromJson({
+        module: {
+          master: dataList,
+        },
+      });
     } on DioError catch (e) {
       AppLogger.instance.error(
         title: 'MDMS Repository',

--- a/apps/health_campaign_field_worker_app/lib/main.dart
+++ b/apps/health_campaign_field_worker_app/lib/main.dart
@@ -70,7 +70,13 @@ void main() async {
     }
   }
   WidgetsBinding.instance.addObserver(AppLifecycleObserver());
-  await DioClient().enableSSLPinning();
+  if (envConfig.variables.envType == EnvType.prod) {
+    try {
+      await DioClient().enableSSLPinning();
+    } catch (e) {
+      debugPrint('SSL pinning failed: $e');
+    }
+  }
   _dio = DioClient().dio;
 
   DigitUi.instance.initThemeComponents();

--- a/apps/health_campaign_field_worker_app/lib/models/app_config/app_config_model.dart
+++ b/apps/health_campaign_field_worker_app/lib/models/app_config/app_config_model.dart
@@ -24,33 +24,14 @@ class MdmsRequestModel with _$MdmsRequestModel {
 class MdmsCriteriaModel with _$MdmsCriteriaModel {
   const factory MdmsCriteriaModel({
     required String tenantId,
-    required List<MdmsModuleDetailModel> moduleDetails,
+    required String schemaCode,
+    Map<String, dynamic>? filters,
+    int? limit,
+    bool? isActive,
   }) = _MdmsCriteriaModel;
 
   factory MdmsCriteriaModel.fromJson(Map<String, dynamic> json) =>
       _$MdmsCriteriaModelFromJson(json);
-}
-
-@freezed
-class MdmsModuleDetailModel with _$MdmsModuleDetailModel {
-  const factory MdmsModuleDetailModel({
-    required String moduleName,
-    required List<MdmsMasterDetailModel> masterDetails,
-  }) = _MdmsModuleDetailModel;
-
-  factory MdmsModuleDetailModel.fromJson(Map<String, dynamic> json) =>
-      _$MdmsModuleDetailModelFromJson(json);
-}
-
-@freezed
-class MdmsMasterDetailModel with _$MdmsMasterDetailModel {
-  const factory MdmsMasterDetailModel(
-      String name, {
-        String? filter,
-      }) = _MdmsMasterDetailModel;
-
-  factory MdmsMasterDetailModel.fromJson(Map<String, dynamic> json) =>
-      _$MdmsMasterDetailModelFromJson(json);
 }
 
 @freezed

--- a/apps/health_campaign_field_worker_app/lib/models/app_config/app_config_model.freezed.dart
+++ b/apps/health_campaign_field_worker_app/lib/models/app_config/app_config_model.freezed.dart
@@ -178,8 +178,10 @@ MdmsCriteriaModel _$MdmsCriteriaModelFromJson(Map<String, dynamic> json) {
 /// @nodoc
 mixin _$MdmsCriteriaModel {
   String get tenantId => throw _privateConstructorUsedError;
-  List<MdmsModuleDetailModel> get moduleDetails =>
-      throw _privateConstructorUsedError;
+  String get schemaCode => throw _privateConstructorUsedError;
+  Map<String, dynamic>? get filters => throw _privateConstructorUsedError;
+  int? get limit => throw _privateConstructorUsedError;
+  bool? get isActive => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -193,7 +195,12 @@ abstract class $MdmsCriteriaModelCopyWith<$Res> {
           MdmsCriteriaModel value, $Res Function(MdmsCriteriaModel) then) =
       _$MdmsCriteriaModelCopyWithImpl<$Res, MdmsCriteriaModel>;
   @useResult
-  $Res call({String tenantId, List<MdmsModuleDetailModel> moduleDetails});
+  $Res call(
+      {String tenantId,
+      String schemaCode,
+      Map<String, dynamic>? filters,
+      int? limit,
+      bool? isActive});
 }
 
 /// @nodoc
@@ -210,17 +217,32 @@ class _$MdmsCriteriaModelCopyWithImpl<$Res, $Val extends MdmsCriteriaModel>
   @override
   $Res call({
     Object? tenantId = null,
-    Object? moduleDetails = null,
+    Object? schemaCode = null,
+    Object? filters = freezed,
+    Object? limit = freezed,
+    Object? isActive = freezed,
   }) {
     return _then(_value.copyWith(
       tenantId: null == tenantId
           ? _value.tenantId
           : tenantId // ignore: cast_nullable_to_non_nullable
               as String,
-      moduleDetails: null == moduleDetails
-          ? _value.moduleDetails
-          : moduleDetails // ignore: cast_nullable_to_non_nullable
-              as List<MdmsModuleDetailModel>,
+      schemaCode: null == schemaCode
+          ? _value.schemaCode
+          : schemaCode // ignore: cast_nullable_to_non_nullable
+              as String,
+      filters: freezed == filters
+          ? _value.filters
+          : filters // ignore: cast_nullable_to_non_nullable
+              as Map<String, dynamic>?,
+      limit: freezed == limit
+          ? _value.limit
+          : limit // ignore: cast_nullable_to_non_nullable
+              as int?,
+      isActive: freezed == isActive
+          ? _value.isActive
+          : isActive // ignore: cast_nullable_to_non_nullable
+              as bool?,
     ) as $Val);
   }
 }
@@ -233,7 +255,12 @@ abstract class _$$MdmsCriteriaModelImplCopyWith<$Res>
       __$$MdmsCriteriaModelImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({String tenantId, List<MdmsModuleDetailModel> moduleDetails});
+  $Res call(
+      {String tenantId,
+      String schemaCode,
+      Map<String, dynamic>? filters,
+      int? limit,
+      bool? isActive});
 }
 
 /// @nodoc
@@ -248,17 +275,32 @@ class __$$MdmsCriteriaModelImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? tenantId = null,
-    Object? moduleDetails = null,
+    Object? schemaCode = null,
+    Object? filters = freezed,
+    Object? limit = freezed,
+    Object? isActive = freezed,
   }) {
     return _then(_$MdmsCriteriaModelImpl(
       tenantId: null == tenantId
           ? _value.tenantId
           : tenantId // ignore: cast_nullable_to_non_nullable
               as String,
-      moduleDetails: null == moduleDetails
-          ? _value._moduleDetails
-          : moduleDetails // ignore: cast_nullable_to_non_nullable
-              as List<MdmsModuleDetailModel>,
+      schemaCode: null == schemaCode
+          ? _value.schemaCode
+          : schemaCode // ignore: cast_nullable_to_non_nullable
+              as String,
+      filters: freezed == filters
+          ? _value._filters
+          : filters // ignore: cast_nullable_to_non_nullable
+              as Map<String, dynamic>?,
+      limit: freezed == limit
+          ? _value.limit
+          : limit // ignore: cast_nullable_to_non_nullable
+              as int?,
+      isActive: freezed == isActive
+          ? _value.isActive
+          : isActive // ignore: cast_nullable_to_non_nullable
+              as bool?,
     ));
   }
 }
@@ -268,25 +310,37 @@ class __$$MdmsCriteriaModelImplCopyWithImpl<$Res>
 class _$MdmsCriteriaModelImpl implements _MdmsCriteriaModel {
   const _$MdmsCriteriaModelImpl(
       {required this.tenantId,
-      required final List<MdmsModuleDetailModel> moduleDetails})
-      : _moduleDetails = moduleDetails;
+      required this.schemaCode,
+      final Map<String, dynamic>? filters,
+      this.limit,
+      this.isActive})
+      : _filters = filters;
 
   factory _$MdmsCriteriaModelImpl.fromJson(Map<String, dynamic> json) =>
       _$$MdmsCriteriaModelImplFromJson(json);
 
   @override
   final String tenantId;
-  final List<MdmsModuleDetailModel> _moduleDetails;
   @override
-  List<MdmsModuleDetailModel> get moduleDetails {
-    if (_moduleDetails is EqualUnmodifiableListView) return _moduleDetails;
+  final String schemaCode;
+  final Map<String, dynamic>? _filters;
+  @override
+  Map<String, dynamic>? get filters {
+    final value = _filters;
+    if (value == null) return null;
+    if (_filters is EqualUnmodifiableMapView) return _filters;
     // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_moduleDetails);
+    return EqualUnmodifiableMapView(value);
   }
 
   @override
+  final int? limit;
+  @override
+  final bool? isActive;
+
+  @override
   String toString() {
-    return 'MdmsCriteriaModel(tenantId: $tenantId, moduleDetails: $moduleDetails)';
+    return 'MdmsCriteriaModel(tenantId: $tenantId, schemaCode: $schemaCode, filters: $filters, limit: $limit, isActive: $isActive)';
   }
 
   @override
@@ -296,14 +350,18 @@ class _$MdmsCriteriaModelImpl implements _MdmsCriteriaModel {
             other is _$MdmsCriteriaModelImpl &&
             (identical(other.tenantId, tenantId) ||
                 other.tenantId == tenantId) &&
-            const DeepCollectionEquality()
-                .equals(other._moduleDetails, _moduleDetails));
+            (identical(other.schemaCode, schemaCode) ||
+                other.schemaCode == schemaCode) &&
+            const DeepCollectionEquality().equals(other._filters, _filters) &&
+            (identical(other.limit, limit) || other.limit == limit) &&
+            (identical(other.isActive, isActive) ||
+                other.isActive == isActive));
   }
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode => Object.hash(runtimeType, tenantId,
-      const DeepCollectionEquality().hash(_moduleDetails));
+  int get hashCode => Object.hash(runtimeType, tenantId, schemaCode,
+      const DeepCollectionEquality().hash(_filters), limit, isActive);
 
   @JsonKey(ignore: true)
   @override
@@ -322,9 +380,11 @@ class _$MdmsCriteriaModelImpl implements _MdmsCriteriaModel {
 
 abstract class _MdmsCriteriaModel implements MdmsCriteriaModel {
   const factory _MdmsCriteriaModel(
-          {required final String tenantId,
-          required final List<MdmsModuleDetailModel> moduleDetails}) =
-      _$MdmsCriteriaModelImpl;
+      {required final String tenantId,
+      required final String schemaCode,
+      final Map<String, dynamic>? filters,
+      final int? limit,
+      final bool? isActive}) = _$MdmsCriteriaModelImpl;
 
   factory _MdmsCriteriaModel.fromJson(Map<String, dynamic> json) =
       _$MdmsCriteriaModelImpl.fromJson;
@@ -332,341 +392,17 @@ abstract class _MdmsCriteriaModel implements MdmsCriteriaModel {
   @override
   String get tenantId;
   @override
-  List<MdmsModuleDetailModel> get moduleDetails;
+  String get schemaCode;
+  @override
+  Map<String, dynamic>? get filters;
+  @override
+  int? get limit;
+  @override
+  bool? get isActive;
   @override
   @JsonKey(ignore: true)
   _$$MdmsCriteriaModelImplCopyWith<_$MdmsCriteriaModelImpl> get copyWith =>
       throw _privateConstructorUsedError;
-}
-
-MdmsModuleDetailModel _$MdmsModuleDetailModelFromJson(
-    Map<String, dynamic> json) {
-  return _MdmsModuleDetailModel.fromJson(json);
-}
-
-/// @nodoc
-mixin _$MdmsModuleDetailModel {
-  String get moduleName => throw _privateConstructorUsedError;
-  List<MdmsMasterDetailModel> get masterDetails =>
-      throw _privateConstructorUsedError;
-
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
-  $MdmsModuleDetailModelCopyWith<MdmsModuleDetailModel> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $MdmsModuleDetailModelCopyWith<$Res> {
-  factory $MdmsModuleDetailModelCopyWith(MdmsModuleDetailModel value,
-          $Res Function(MdmsModuleDetailModel) then) =
-      _$MdmsModuleDetailModelCopyWithImpl<$Res, MdmsModuleDetailModel>;
-  @useResult
-  $Res call({String moduleName, List<MdmsMasterDetailModel> masterDetails});
-}
-
-/// @nodoc
-class _$MdmsModuleDetailModelCopyWithImpl<$Res,
-        $Val extends MdmsModuleDetailModel>
-    implements $MdmsModuleDetailModelCopyWith<$Res> {
-  _$MdmsModuleDetailModelCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? moduleName = null,
-    Object? masterDetails = null,
-  }) {
-    return _then(_value.copyWith(
-      moduleName: null == moduleName
-          ? _value.moduleName
-          : moduleName // ignore: cast_nullable_to_non_nullable
-              as String,
-      masterDetails: null == masterDetails
-          ? _value.masterDetails
-          : masterDetails // ignore: cast_nullable_to_non_nullable
-              as List<MdmsMasterDetailModel>,
-    ) as $Val);
-  }
-}
-
-/// @nodoc
-abstract class _$$MdmsModuleDetailModelImplCopyWith<$Res>
-    implements $MdmsModuleDetailModelCopyWith<$Res> {
-  factory _$$MdmsModuleDetailModelImplCopyWith(
-          _$MdmsModuleDetailModelImpl value,
-          $Res Function(_$MdmsModuleDetailModelImpl) then) =
-      __$$MdmsModuleDetailModelImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({String moduleName, List<MdmsMasterDetailModel> masterDetails});
-}
-
-/// @nodoc
-class __$$MdmsModuleDetailModelImplCopyWithImpl<$Res>
-    extends _$MdmsModuleDetailModelCopyWithImpl<$Res,
-        _$MdmsModuleDetailModelImpl>
-    implements _$$MdmsModuleDetailModelImplCopyWith<$Res> {
-  __$$MdmsModuleDetailModelImplCopyWithImpl(_$MdmsModuleDetailModelImpl _value,
-      $Res Function(_$MdmsModuleDetailModelImpl) _then)
-      : super(_value, _then);
-
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? moduleName = null,
-    Object? masterDetails = null,
-  }) {
-    return _then(_$MdmsModuleDetailModelImpl(
-      moduleName: null == moduleName
-          ? _value.moduleName
-          : moduleName // ignore: cast_nullable_to_non_nullable
-              as String,
-      masterDetails: null == masterDetails
-          ? _value._masterDetails
-          : masterDetails // ignore: cast_nullable_to_non_nullable
-              as List<MdmsMasterDetailModel>,
-    ));
-  }
-}
-
-/// @nodoc
-@JsonSerializable()
-class _$MdmsModuleDetailModelImpl implements _MdmsModuleDetailModel {
-  const _$MdmsModuleDetailModelImpl(
-      {required this.moduleName,
-      required final List<MdmsMasterDetailModel> masterDetails})
-      : _masterDetails = masterDetails;
-
-  factory _$MdmsModuleDetailModelImpl.fromJson(Map<String, dynamic> json) =>
-      _$$MdmsModuleDetailModelImplFromJson(json);
-
-  @override
-  final String moduleName;
-  final List<MdmsMasterDetailModel> _masterDetails;
-  @override
-  List<MdmsMasterDetailModel> get masterDetails {
-    if (_masterDetails is EqualUnmodifiableListView) return _masterDetails;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_masterDetails);
-  }
-
-  @override
-  String toString() {
-    return 'MdmsModuleDetailModel(moduleName: $moduleName, masterDetails: $masterDetails)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$MdmsModuleDetailModelImpl &&
-            (identical(other.moduleName, moduleName) ||
-                other.moduleName == moduleName) &&
-            const DeepCollectionEquality()
-                .equals(other._masterDetails, _masterDetails));
-  }
-
-  @JsonKey(ignore: true)
-  @override
-  int get hashCode => Object.hash(runtimeType, moduleName,
-      const DeepCollectionEquality().hash(_masterDetails));
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$MdmsModuleDetailModelImplCopyWith<_$MdmsModuleDetailModelImpl>
-      get copyWith => __$$MdmsModuleDetailModelImplCopyWithImpl<
-          _$MdmsModuleDetailModelImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$MdmsModuleDetailModelImplToJson(
-      this,
-    );
-  }
-}
-
-abstract class _MdmsModuleDetailModel implements MdmsModuleDetailModel {
-  const factory _MdmsModuleDetailModel(
-          {required final String moduleName,
-          required final List<MdmsMasterDetailModel> masterDetails}) =
-      _$MdmsModuleDetailModelImpl;
-
-  factory _MdmsModuleDetailModel.fromJson(Map<String, dynamic> json) =
-      _$MdmsModuleDetailModelImpl.fromJson;
-
-  @override
-  String get moduleName;
-  @override
-  List<MdmsMasterDetailModel> get masterDetails;
-  @override
-  @JsonKey(ignore: true)
-  _$$MdmsModuleDetailModelImplCopyWith<_$MdmsModuleDetailModelImpl>
-      get copyWith => throw _privateConstructorUsedError;
-}
-
-MdmsMasterDetailModel _$MdmsMasterDetailModelFromJson(
-    Map<String, dynamic> json) {
-  return _MdmsMasterDetailModel.fromJson(json);
-}
-
-/// @nodoc
-mixin _$MdmsMasterDetailModel {
-  String get name => throw _privateConstructorUsedError;
-  String? get filter => throw _privateConstructorUsedError;
-
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-  @JsonKey(ignore: true)
-  $MdmsMasterDetailModelCopyWith<MdmsMasterDetailModel> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $MdmsMasterDetailModelCopyWith<$Res> {
-  factory $MdmsMasterDetailModelCopyWith(MdmsMasterDetailModel value,
-          $Res Function(MdmsMasterDetailModel) then) =
-      _$MdmsMasterDetailModelCopyWithImpl<$Res, MdmsMasterDetailModel>;
-  @useResult
-  $Res call({String name, String? filter});
-}
-
-/// @nodoc
-class _$MdmsMasterDetailModelCopyWithImpl<$Res,
-        $Val extends MdmsMasterDetailModel>
-    implements $MdmsMasterDetailModelCopyWith<$Res> {
-  _$MdmsMasterDetailModelCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? name = null,
-    Object? filter = freezed,
-  }) {
-    return _then(_value.copyWith(
-      name: null == name
-          ? _value.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String,
-      filter: freezed == filter
-          ? _value.filter
-          : filter // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ) as $Val);
-  }
-}
-
-/// @nodoc
-abstract class _$$MdmsMasterDetailModelImplCopyWith<$Res>
-    implements $MdmsMasterDetailModelCopyWith<$Res> {
-  factory _$$MdmsMasterDetailModelImplCopyWith(
-          _$MdmsMasterDetailModelImpl value,
-          $Res Function(_$MdmsMasterDetailModelImpl) then) =
-      __$$MdmsMasterDetailModelImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call({String name, String? filter});
-}
-
-/// @nodoc
-class __$$MdmsMasterDetailModelImplCopyWithImpl<$Res>
-    extends _$MdmsMasterDetailModelCopyWithImpl<$Res,
-        _$MdmsMasterDetailModelImpl>
-    implements _$$MdmsMasterDetailModelImplCopyWith<$Res> {
-  __$$MdmsMasterDetailModelImplCopyWithImpl(_$MdmsMasterDetailModelImpl _value,
-      $Res Function(_$MdmsMasterDetailModelImpl) _then)
-      : super(_value, _then);
-
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? name = null,
-    Object? filter = freezed,
-  }) {
-    return _then(_$MdmsMasterDetailModelImpl(
-      null == name
-          ? _value.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String,
-      filter: freezed == filter
-          ? _value.filter
-          : filter // ignore: cast_nullable_to_non_nullable
-              as String?,
-    ));
-  }
-}
-
-/// @nodoc
-@JsonSerializable()
-class _$MdmsMasterDetailModelImpl implements _MdmsMasterDetailModel {
-  const _$MdmsMasterDetailModelImpl(this.name, {this.filter});
-
-  factory _$MdmsMasterDetailModelImpl.fromJson(Map<String, dynamic> json) =>
-      _$$MdmsMasterDetailModelImplFromJson(json);
-
-  @override
-  final String name;
-  @override
-  final String? filter;
-
-  @override
-  String toString() {
-    return 'MdmsMasterDetailModel(name: $name, filter: $filter)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$MdmsMasterDetailModelImpl &&
-            (identical(other.name, name) || other.name == name) &&
-            (identical(other.filter, filter) || other.filter == filter));
-  }
-
-  @JsonKey(ignore: true)
-  @override
-  int get hashCode => Object.hash(runtimeType, name, filter);
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$MdmsMasterDetailModelImplCopyWith<_$MdmsMasterDetailModelImpl>
-      get copyWith => __$$MdmsMasterDetailModelImplCopyWithImpl<
-          _$MdmsMasterDetailModelImpl>(this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$MdmsMasterDetailModelImplToJson(
-      this,
-    );
-  }
-}
-
-abstract class _MdmsMasterDetailModel implements MdmsMasterDetailModel {
-  const factory _MdmsMasterDetailModel(final String name,
-      {final String? filter}) = _$MdmsMasterDetailModelImpl;
-
-  factory _MdmsMasterDetailModel.fromJson(Map<String, dynamic> json) =
-      _$MdmsMasterDetailModelImpl.fromJson;
-
-  @override
-  String get name;
-  @override
-  String? get filter;
-  @override
-  @JsonKey(ignore: true)
-  _$$MdmsMasterDetailModelImplCopyWith<_$MdmsMasterDetailModelImpl>
-      get copyWith => throw _privateConstructorUsedError;
 }
 
 AppConfigPrimaryWrapperModel _$AppConfigPrimaryWrapperModelFromJson(

--- a/apps/health_campaign_field_worker_app/lib/models/app_config/app_config_model.g.dart
+++ b/apps/health_campaign_field_worker_app/lib/models/app_config/app_config_model.g.dart
@@ -23,46 +23,20 @@ _$MdmsCriteriaModelImpl _$$MdmsCriteriaModelImplFromJson(
         Map<String, dynamic> json) =>
     _$MdmsCriteriaModelImpl(
       tenantId: json['tenantId'] as String,
-      moduleDetails: (json['moduleDetails'] as List<dynamic>)
-          .map((e) => MdmsModuleDetailModel.fromJson(e as Map<String, dynamic>))
-          .toList(),
+      schemaCode: json['schemaCode'] as String,
+      filters: json['filters'] as Map<String, dynamic>?,
+      limit: (json['limit'] as num?)?.toInt(),
+      isActive: json['isActive'] as bool?,
     );
 
 Map<String, dynamic> _$$MdmsCriteriaModelImplToJson(
         _$MdmsCriteriaModelImpl instance) =>
     <String, dynamic>{
       'tenantId': instance.tenantId,
-      'moduleDetails': instance.moduleDetails,
-    };
-
-_$MdmsModuleDetailModelImpl _$$MdmsModuleDetailModelImplFromJson(
-        Map<String, dynamic> json) =>
-    _$MdmsModuleDetailModelImpl(
-      moduleName: json['moduleName'] as String,
-      masterDetails: (json['masterDetails'] as List<dynamic>)
-          .map((e) => MdmsMasterDetailModel.fromJson(e as Map<String, dynamic>))
-          .toList(),
-    );
-
-Map<String, dynamic> _$$MdmsModuleDetailModelImplToJson(
-        _$MdmsModuleDetailModelImpl instance) =>
-    <String, dynamic>{
-      'moduleName': instance.moduleName,
-      'masterDetails': instance.masterDetails,
-    };
-
-_$MdmsMasterDetailModelImpl _$$MdmsMasterDetailModelImplFromJson(
-        Map<String, dynamic> json) =>
-    _$MdmsMasterDetailModelImpl(
-      json['name'] as String,
-      filter: json['filter'] as String?,
-    );
-
-Map<String, dynamic> _$$MdmsMasterDetailModelImplToJson(
-        _$MdmsMasterDetailModelImpl instance) =>
-    <String, dynamic>{
-      'name': instance.name,
-      'filter': instance.filter,
+      'schemaCode': instance.schemaCode,
+      'filters': instance.filters,
+      'limit': instance.limit,
+      'isActive': instance.isActive,
     };
 
 _$AppConfigPrimaryWrapperModelImpl _$$AppConfigPrimaryWrapperModelImplFromJson(

--- a/apps/health_campaign_field_worker_app/lib/models/entities/mdms_master_enums.dart
+++ b/apps/health_campaign_field_worker_app/lib/models/entities/mdms_master_enums.dart
@@ -68,5 +68,11 @@ enum MasterEnums {
   @MappableValue("SINGLE_USER_LOGIN")
   singleUserLogin,
   @MappableValue("BOUNDARY_RELATIONSHIP")
-  boundaryRelationShip
+  boundaryRelationShip,
+  @MappableValue("serviceRegistry")
+  serviceRegistryMaster,
+  @MappableValue("projectTypes")
+  projectTypes,
+  @MappableValue("FormConfig")
+  formConfig
 }

--- a/apps/health_campaign_field_worker_app/lib/models/entities/mdms_master_enums.mapper.dart
+++ b/apps/health_campaign_field_worker_app/lib/models/entities/mdms_master_enums.mapper.dart
@@ -89,6 +89,12 @@ class MasterEnumsMapper extends EnumMapper<MasterEnums> {
         return MasterEnums.singleUserLogin;
       case "BOUNDARY_RELATIONSHIP":
         return MasterEnums.boundaryRelationShip;
+      case "serviceRegistry":
+        return MasterEnums.serviceRegistryMaster;
+      case "projectTypes":
+        return MasterEnums.projectTypes;
+      case "FormConfig":
+        return MasterEnums.formConfig;
       default:
         throw MapperException.unknownEnumValue(value);
     }
@@ -161,6 +167,12 @@ class MasterEnumsMapper extends EnumMapper<MasterEnums> {
         return "SINGLE_USER_LOGIN";
       case MasterEnums.boundaryRelationShip:
         return "BOUNDARY_RELATIONSHIP";
+      case MasterEnums.serviceRegistryMaster:
+        return "serviceRegistry";
+      case MasterEnums.projectTypes:
+        return "projectTypes";
+      case MasterEnums.formConfig:
+        return "FormConfig";
     }
   }
 }

--- a/apps/health_campaign_field_worker_app/lib/models/entities/mdms_module_enums.dart
+++ b/apps/health_campaign_field_worker_app/lib/models/entities/mdms_module_enums.dart
@@ -15,4 +15,8 @@ enum ModuleEnums {
   moduleVersion,
   @MappableValue("RAINMAKER-PGR")
   rainmakerPgr,
+  @MappableValue("HCM-ADMIN-CONSOLE")
+  hcmAdminConsole,
+  @MappableValue("HCM-PROJECT-TYPES")
+  hcmProjectTypes,
 }

--- a/apps/health_campaign_field_worker_app/lib/models/entities/mdms_module_enums.mapper.dart
+++ b/apps/health_campaign_field_worker_app/lib/models/entities/mdms_module_enums.mapper.dart
@@ -35,6 +35,10 @@ class ModuleEnumsMapper extends EnumMapper<ModuleEnums> {
         return ModuleEnums.moduleVersion;
       case "RAINMAKER-PGR":
         return ModuleEnums.rainmakerPgr;
+      case "HCM-ADMIN-CONSOLE":
+        return ModuleEnums.hcmAdminConsole;
+      case "HCM-PROJECT-TYPES":
+        return ModuleEnums.hcmProjectTypes;
       default:
         throw MapperException.unknownEnumValue(value);
     }
@@ -53,6 +57,10 @@ class ModuleEnumsMapper extends EnumMapper<ModuleEnums> {
         return "module-version";
       case ModuleEnums.rainmakerPgr:
         return "RAINMAKER-PGR";
+      case ModuleEnums.hcmAdminConsole:
+        return "HCM-ADMIN-CONSOLE";
+      case ModuleEnums.hcmProjectTypes:
+        return "HCM-PROJECT-TYPES";
     }
   }
 }

--- a/apps/health_campaign_field_worker_app/lib/pages/home.dart
+++ b/apps/health_campaign_field_worker_app/lib/pages/home.dart
@@ -2845,7 +2845,11 @@ class _HomePageState extends LocalizedState<HomePage> {
                 .map((e) => e.displayName)
                 .toList()
                 .contains(element) ||
-            element == i18.home.db)
+            element == i18.home.db ||
+            (isPolio &&
+                element == i18.home.polioLqaDataCollectionLabel) ||
+            (isPolio &&
+                element == i18.home.polioInsideMonitoringLabel))
         .where(
             (element) => !(isPolio && element == i18.home.stockSyncDataLabel))
         .toList();

--- a/apps/health_campaign_field_worker_app/lib/sampleJsonConfigs/polio_inside_household_monitoring.dart
+++ b/apps/health_campaign_field_worker_app/lib/sampleJsonConfigs/polio_inside_household_monitoring.dart
@@ -6,44 +6,26 @@ final dynamic samplePolioInsideHouseholdMonitoringFlows = {
   "disabled": false,
   "isSelected": true,
   "flows": [
-    // ══════════════════════════════════════════════════════════════════════
-    // Flow 1: insideHouseholdEntry (FORM) — 3 pages
-    // ══════════════════════════════════════════════════════════════════════
     {
-      "screenType": "FORM",
       "name": "insideHouseholdEntry",
-      "project": "POLIO-SIA",
-      "version": 1,
-      "disabled": false,
-      "isSelected": true,
-      "initActions": [],
-      "wrapperConfig": {},
-      "includeSummary": true,
+      "order": 1,
       "pages": [
-        // ── Page 1: First Household Location ──
         {
           "page": "firstHouseholdLocation",
+          "type": "object",
           "label": "IHM_FIRST_HOUSEHOLD_LOCATION_LABEL",
           "order": 1,
-          "type": "object",
-          "description": "IHM_FIRST_HOUSEHOLD_LOCATION_DESC",
-          "actionLabel": "IHM_NEXT",
           "value": null,
-          "required": null,
           "hidden": null,
-          "helpText": null,
-          "innerLabel": null,
-          "validations": null,
-          "tooltip": null,
-          "startDate": null,
           "endDate": null,
+          "tooltip": null,
+          "helpText": null,
           "readOnly": null,
+          "required": null,
           "charCount": null,
-          "systemDate": null,
-          "isMultiSelect": null,
-          "includeInForm": null,
-          "includeInSummary": null,
+          "startDate": null,
           "autoEnable": null,
+          "innerLabel": null,
           "navigateTo": {"name": "monitoringDetails", "type": "form"},
           "properties": [
             {
@@ -68,65 +50,39 @@ final dynamic samplePolioInsideHouseholdMonitoringFlows = {
                   "message": "IHM_VALIDATION_REQUIRED"
                 }
               ],
-              "errorMessage": "",
+              "errorMessage":
+                  "INSIDEMONITORING_INSIDEHOUSEHOLDENTRY_gpsFirstHousehold_ERROR",
               "isMultiSelect": false
             }
-          ]
+          ],
+          "systemDate": null,
+          "actionLabel": "IHM_NEXT",
+          "description": "IHM_FIRST_HOUSEHOLD_LOCATION_DESC",
+          "validations": null,
+          "includeInForm": null,
+          "isMultiSelect": null,
+          "includeInSummary": null
         },
-
-        // ── Page 2: Monitoring Details ──
         {
           "page": "monitoringDetails",
+          "type": "object",
           "label": "IHM_MONITORING_DETAILS_LABEL",
           "order": 2,
-          "type": "object",
-          "description": "IHM_MONITORING_DETAILS_DESC",
-          "actionLabel": "IHM_NEXT",
           "value": null,
-          "required": null,
           "hidden": null,
-          "helpText": null,
-          "innerLabel": null,
-          "validations": null,
-          "tooltip": null,
-          "startDate": null,
           "endDate": null,
+          "tooltip": null,
+          "helpText": null,
           "readOnly": null,
+          "required": null,
           "charCount": null,
-          "systemDate": null,
-          "isMultiSelect": null,
-          "includeInForm": null,
-          "includeInSummary": null,
+          "startDate": null,
           "autoEnable": null,
+          "innerLabel": null,
           "navigateTo": {"name": "closeout", "type": "form"},
           "properties": [
-            // ── Monitor info ──
-
-            // 1. monitorDesignation
             {
               "type": "string",
-              "label": "IHM_MONITOR_DESIGNATION_LABEL",
-              "order": 1,
-              "value": "",
-              "format": "dropdown",
-              "hidden": false,
-              "tooltip": "",
-              "helpText": "",
-              "infoText": "",
-              "readOnly": false,
-              "fieldName": "monitorDesignation",
-              "deleteFlag": false,
-              "innerLabel": "",
-              "systemDate": false,
-              "validations": [
-                {
-                  "type": "required",
-                  "value": true,
-                  "message": "IHM_VALIDATION_REQUIRED"
-                }
-              ],
-              "errorMessage": "",
-              "isMultiSelect": false,
               "enums": [
                 {"code": "WHO_HQ", "name": "IHM_ENUM_WHO_HQ"},
                 {"code": "WHO_REGION", "name": "IHM_ENUM_WHO_REGION"},
@@ -158,10 +114,31 @@ final dynamic samplePolioInsideHouseholdMonitoringFlows = {
                 {"code": "VOLUNTEER", "name": "IHM_ENUM_VOLUNTEER"},
                 {"code": "STUDENT", "name": "IHM_ENUM_STUDENT"},
                 {"code": "OTHERS", "name": "IHM_ENUM_OTHERS"}
-              ]
+              ],
+              "label": "IHM_MONITOR_DESIGNATION_LABEL",
+              "order": 1,
+              "value": "",
+              "format": "dropdown",
+              "hidden": false,
+              "tooltip": "",
+              "helpText": "",
+              "infoText": "",
+              "readOnly": false,
+              "fieldName": "monitorDesignation",
+              "deleteFlag": false,
+              "innerLabel": "",
+              "systemDate": false,
+              "validations": [
+                {
+                  "type": "required",
+                  "value": true,
+                  "message": "IHM_VALIDATION_REQUIRED"
+                }
+              ],
+              "errorMessage":
+                  "INSIDEMONITORING_INSIDEHOUSEHOLDENTRY_monitorDesignation_ERROR",
+              "isMultiSelect": false
             },
-
-            // 2. designationOther
             {
               "type": "string",
               "label": "IHM_DESIGNATION_OTHER_LABEL",
@@ -183,17 +160,19 @@ final dynamic samplePolioInsideHouseholdMonitoringFlows = {
               "visibilityCondition": {
                 "expression": [
                   {
+                    "type": "custom",
                     "condition":
-                        "monitoringDetails.monitorDesignation=='OTHERS'",
-                    "type": "custom"
+                        "monitoringDetails.monitorDesignation=='OTHERS'"
                   }
                 ]
               }
             },
-
-            // 3. monitoringType
             {
               "type": "string",
+              "enums": [
+                {"code": "IN_PROCESS", "name": "IHM_ENUM_IN_PROCESS"},
+                {"code": "END_PROCESS", "name": "IHM_ENUM_END_PROCESS"}
+              ],
               "label": "IHM_MONITORING_TYPE_LABEL",
               "order": 3,
               "value": "",
@@ -214,21 +193,16 @@ final dynamic samplePolioInsideHouseholdMonitoringFlows = {
                   "message": "IHM_VALIDATION_REQUIRED"
                 }
               ],
-              "errorMessage": "",
-              "isMultiSelect": false,
-              "enums": [
-                {"code": "IN_PROCESS", "name": "IHM_ENUM_IN_PROCESS"},
-                {"code": "END_PROCESS", "name": "IHM_ENUM_END_PROCESS"}
-              ]
+              "errorMessage":
+                  "INSIDEMONITORING_INSIDEHOUSEHOLDENTRY_monitoringType_ERROR",
+              "isMultiSelect": false
             },
-
-            // 4. monitoringDate
             {
               "type": "string",
               "label": "IHM_MONITORING_DATE_LABEL",
               "order": 4,
               "value": "",
-              "format": "text",
+              "format": "date",
               "hidden": false,
               "tooltip": "",
               "helpText": "",
@@ -245,11 +219,10 @@ final dynamic samplePolioInsideHouseholdMonitoringFlows = {
                   "message": "IHM_VALIDATION_REQUIRED"
                 }
               ],
-              "errorMessage": "",
+              "errorMessage":
+                  "INSIDEMONITORING_INSIDEHOUSEHOLDENTRY_monitoringDate_ERROR",
               "isMultiSelect": false
             },
-
-            // 5. settlementArea
             {
               "type": "string",
               "label": "IHM_SETTLEMENT_AREA_LABEL",
@@ -269,32 +242,30 @@ final dynamic samplePolioInsideHouseholdMonitoringFlows = {
               "errorMessage": "",
               "isMultiSelect": false
             },
-
-            // 7. settlementType
             {
               "type": "string",
-              "label": "IHM_SETTLEMENT_TYPE_LABEL",
-              "order": 7,
+              "label": "IHM_SETTLEMENT_NAME_LABEL",
+              "order": 6,
               "value": "",
-              "format": "dropdown",
+              "format": "text",
               "hidden": false,
               "tooltip": "",
               "helpText": "",
               "infoText": "",
               "readOnly": true,
-              "fieldName": "settlementType",
+              "fieldName": "settlementName",
               "deleteFlag": false,
               "innerLabel": "",
               "systemDate": false,
-              "validations": [
-                {
-                  "type": "required",
-                  "value": true,
-                  "message": "IHM_VALIDATION_REQUIRED"
-                }
-              ],
+              "validations": [],
               "errorMessage": "",
               "isMultiSelect": false,
+              "autoFillCondition": [
+                {"value": "{{settlementName}}", "expression": "true==true"}
+              ]
+            },
+            {
+              "type": "string",
               "enums": [
                 {"code": "URBAN", "name": "IHM_ENUM_URBAN"},
                 {"code": "RURAL", "name": "IHM_ENUM_RURAL"},
@@ -309,12 +280,36 @@ final dynamic samplePolioInsideHouseholdMonitoringFlows = {
                 {"code": "IMMIGRANTS", "name": "IHM_ENUM_IMMIGRANTS"},
                 {"code": "CROSS_BORDER", "name": "IHM_ENUM_CROSS_BORDER"}
               ],
+              "label": "IHM_SETTLEMENT_TYPE_LABEL",
+              "order": 7,
+              "value": "",
+              "format": "dropdown",
+              "hidden": false,
+              "tooltip": "",
+              "helpText": "",
+              "infoText": "",
+              "readOnly": false,
+              "fieldName": "settlementType",
+              "deleteFlag": false,
+              "innerLabel": "",
+              "systemDate": false,
+              "validations": [
+                {
+                  "type": "required",
+                  "value": true,
+                  "message": "IHM_VALIDATION_REQUIRED"
+                }
+              ],
+              "errorMessage":
+                  "INSIDEMONITORING_INSIDEHOUSEHOLDENTRY_settlementType_ERROR",
+              "isMultiSelect": false,
               "autoFillCondition": [
-                {"value": "{{singleton.settlementType}}", "expression": "true==true"}
+                {
+                  "value": "{{singleton.settlementType}}",
+                  "expression": "true==true"
+                }
               ]
             },
-
-            // 8. monitorName
             {
               "type": "string",
               "label": "IHM_MONITOR_NAME_LABEL",
@@ -337,17 +332,13 @@ final dynamic samplePolioInsideHouseholdMonitoringFlows = {
                   "message": "IHM_VALIDATION_REQUIRED"
                 }
               ],
-              "errorMessage": "",
+              "errorMessage":
+                  "INSIDEMONITORING_INSIDEHOUSEHOLDENTRY_monitorName_ERROR",
               "isMultiSelect": false,
               "autoFillCondition": [
-                {
-                  "value": "{{loggedInUserName}}",
-                  "expression": "true==true"
-                }
+                {"value": "{{loggedInUserName}}", "expression": "true==true"}
               ]
             },
-
-            // 9. monitorPhone
             {
               "type": "string",
               "label": "IHM_MONITOR_PHONE_LABEL",
@@ -373,12 +364,12 @@ final dynamic samplePolioInsideHouseholdMonitoringFlows = {
                 }
               ]
             },
-
-            // ── Household-level questions (A through P) ──
-
-            // A. teamVisited
             {
               "type": "string",
+              "enums": [
+                {"code": "YES", "name": "IHM_ENUM_YES"},
+                {"code": "NO", "name": "IHM_ENUM_NO"}
+              ],
               "label": "IHM_TEAM_VISITED_LABEL",
               "order": 10,
               "value": "",
@@ -399,17 +390,16 @@ final dynamic samplePolioInsideHouseholdMonitoringFlows = {
                   "message": "IHM_VALIDATION_REQUIRED"
                 }
               ],
-              "errorMessage": "",
-              "isMultiSelect": false,
+              "errorMessage":
+                  "INSIDEMONITORING_INSIDEHOUSEHOLDENTRY_teamVisited_ERROR",
+              "isMultiSelect": false
+            },
+            {
+              "type": "string",
               "enums": [
                 {"code": "YES", "name": "IHM_ENUM_YES"},
                 {"code": "NO", "name": "IHM_ENUM_NO"}
-              ]
-            },
-
-            // B. houseMarked
-            {
-              "type": "string",
+              ],
               "label": "IHM_HOUSE_MARKED_LABEL",
               "order": 11,
               "value": "",
@@ -426,21 +416,15 @@ final dynamic samplePolioInsideHouseholdMonitoringFlows = {
               "validations": [],
               "errorMessage": "",
               "isMultiSelect": false,
-              "enums": [
-                {"code": "YES", "name": "IHM_ENUM_YES"},
-                {"code": "NO", "name": "IHM_ENUM_NO"}
-              ],
               "visibilityCondition": {
                 "expression": [
                   {
-                    "condition": "monitoringDetails.teamVisited=='YES'",
-                    "type": "custom"
+                    "type": "custom",
+                    "condition": "monitoringDetails.teamVisited=='YES'"
                   }
                 ]
               }
             },
-
-            // C. childrenPresent
             {
               "type": "integer",
               "label": "IHM_CHILDREN_PRESENT_LABEL",
@@ -469,11 +453,10 @@ final dynamic samplePolioInsideHouseholdMonitoringFlows = {
                   "message": "IHM_VALIDATION_MIN_ZERO"
                 }
               ],
-              "errorMessage": "",
+              "errorMessage":
+                  "INSIDEMONITORING_INSIDEHOUSEHOLDENTRY_childrenPresent_ERROR",
               "isMultiSelect": false
             },
-
-            // D. childrenVaccinated
             {
               "type": "integer",
               "label": "IHM_CHILDREN_VACCINATED_LABEL",
@@ -502,29 +485,12 @@ final dynamic samplePolioInsideHouseholdMonitoringFlows = {
                   "message": "IHM_VALIDATION_MIN_ZERO"
                 }
               ],
-              "errorMessage": "",
+              "errorMessage":
+                  "INSIDEMONITORING_INSIDEHOUSEHOLDENTRY_childrenVaccinated_ERROR",
               "isMultiSelect": false
             },
-
-            // E. vaccinationLocation
             {
               "type": "string",
-              "label": "IHM_VACCINATION_LOCATION_LABEL",
-              "order": 14,
-              "value": "",
-              "format": "dropdown",
-              "hidden": false,
-              "tooltip": "",
-              "helpText": "",
-              "infoText": "",
-              "readOnly": false,
-              "fieldName": "vaccinationLocation",
-              "deleteFlag": false,
-              "innerLabel": "",
-              "systemDate": false,
-              "validations": [],
-              "errorMessage": "",
-              "isMultiSelect": false,
               "enums": [
                 {"code": "HOUSE", "name": "IHM_ENUM_HOUSE"},
                 {"code": "HEALTH_FACILITY", "name": "IHM_ENUM_HEALTH_FACILITY"},
@@ -542,10 +508,24 @@ final dynamic samplePolioInsideHouseholdMonitoringFlows = {
                 },
                 {"code": "PLAYGROUND", "name": "IHM_ENUM_PLAYGROUND"},
                 {"code": "OTHER", "name": "IHM_ENUM_OTHER"}
-              ]
+              ],
+              "label": "IHM_VACCINATION_LOCATION_LABEL",
+              "order": 14,
+              "value": "",
+              "format": "dropdown",
+              "hidden": false,
+              "tooltip": "",
+              "helpText": "",
+              "infoText": "",
+              "readOnly": false,
+              "fieldName": "vaccinationLocation",
+              "deleteFlag": false,
+              "innerLabel": "",
+              "systemDate": false,
+              "validations": [],
+              "errorMessage": "",
+              "isMultiSelect": false
             },
-
-            // F. missedAbsent
             {
               "type": "integer",
               "label": "IHM_MISSED_ABSENT_LABEL",
@@ -569,11 +549,10 @@ final dynamic samplePolioInsideHouseholdMonitoringFlows = {
                   "message": "IHM_VALIDATION_MIN_ZERO"
                 }
               ],
-              "errorMessage": "",
+              "errorMessage":
+                  "INSIDEMONITORING_INSIDEHOUSEHOLDENTRY_missedAbsent_ERROR",
               "isMultiSelect": false
             },
-
-            // G. missedRefusal
             {
               "type": "integer",
               "label": "IHM_MISSED_REFUSAL_LABEL",
@@ -597,11 +576,10 @@ final dynamic samplePolioInsideHouseholdMonitoringFlows = {
                   "message": "IHM_VALIDATION_MIN_ZERO"
                 }
               ],
-              "errorMessage": "",
+              "errorMessage":
+                  "INSIDEMONITORING_INSIDEHOUSEHOLDENTRY_missedRefusal_ERROR",
               "isMultiSelect": false
             },
-
-            // H. missedNotVisited
             {
               "type": "integer",
               "label": "IHM_MISSED_NOT_VISITED_LABEL",
@@ -625,11 +603,10 @@ final dynamic samplePolioInsideHouseholdMonitoringFlows = {
                   "message": "IHM_VALIDATION_MIN_ZERO"
                 }
               ],
-              "errorMessage": "",
+              "errorMessage":
+                  "INSIDEMONITORING_INSIDEHOUSEHOLDENTRY_missedNotVisited_ERROR",
               "isMultiSelect": false
             },
-
-            // I. missedNotRevisited
             {
               "type": "integer",
               "label": "IHM_MISSED_NOT_REVISITED_LABEL",
@@ -653,11 +630,10 @@ final dynamic samplePolioInsideHouseholdMonitoringFlows = {
                   "message": "IHM_VALIDATION_MIN_ZERO"
                 }
               ],
-              "errorMessage": "",
+              "errorMessage":
+                  "INSIDEMONITORING_INSIDEHOUSEHOLDENTRY_missedNotRevisited_ERROR",
               "isMultiSelect": false
             },
-
-            // J. missedAsleep
             {
               "type": "integer",
               "label": "IHM_MISSED_ASLEEP_LABEL",
@@ -681,11 +657,10 @@ final dynamic samplePolioInsideHouseholdMonitoringFlows = {
                   "message": "IHM_VALIDATION_MIN_ZERO"
                 }
               ],
-              "errorMessage": "",
+              "errorMessage":
+                  "INSIDEMONITORING_INSIDEHOUSEHOLDENTRY_missedAsleep_ERROR",
               "isMultiSelect": false
             },
-
-            // K. missedRoutine
             {
               "type": "integer",
               "label": "IHM_MISSED_ROUTINE_LABEL",
@@ -709,11 +684,10 @@ final dynamic samplePolioInsideHouseholdMonitoringFlows = {
                   "message": "IHM_VALIDATION_MIN_ZERO"
                 }
               ],
-              "errorMessage": "",
+              "errorMessage":
+                  "INSIDEMONITORING_INSIDEHOUSEHOLDENTRY_missedRoutine_ERROR",
               "isMultiSelect": false
             },
-
-            // L. missedOther
             {
               "type": "integer",
               "label": "IHM_MISSED_OTHER_LABEL",
@@ -737,13 +711,16 @@ final dynamic samplePolioInsideHouseholdMonitoringFlows = {
                   "message": "IHM_VALIDATION_MIN_ZERO"
                 }
               ],
-              "errorMessage": "",
+              "errorMessage":
+                  "INSIDEMONITORING_INSIDEHOUSEHOLDENTRY_missedOther_ERROR",
               "isMultiSelect": false
             },
-
-            // M. caregiverInformed
             {
               "type": "string",
+              "enums": [
+                {"code": "YES", "name": "IHM_ENUM_YES"},
+                {"code": "NO", "name": "IHM_ENUM_NO"}
+              ],
               "label": "IHM_CAREGIVER_INFORMED_LABEL",
               "order": 22,
               "value": "",
@@ -764,33 +741,12 @@ final dynamic samplePolioInsideHouseholdMonitoringFlows = {
                   "message": "IHM_VALIDATION_REQUIRED"
                 }
               ],
-              "errorMessage": "",
-              "isMultiSelect": false,
-              "enums": [
-                {"code": "YES", "name": "IHM_ENUM_YES"},
-                {"code": "NO", "name": "IHM_ENUM_NO"}
-              ]
+              "errorMessage":
+                  "INSIDEMONITORING_INSIDEHOUSEHOLDENTRY_caregiverInformed_ERROR",
+              "isMultiSelect": false
             },
-
-            // N. campaignInfoSource (multi-select)
             {
               "type": "string",
-              "label": "IHM_CAMPAIGN_INFO_SOURCE_LABEL",
-              "order": 23,
-              "value": "",
-              "format": "dropdown",
-              "hidden": false,
-              "tooltip": "",
-              "helpText": "",
-              "infoText": "",
-              "readOnly": false,
-              "fieldName": "campaignInfoSource",
-              "deleteFlag": false,
-              "innerLabel": "",
-              "systemDate": false,
-              "validations": [],
-              "errorMessage": "",
-              "isMultiSelect": true,
               "enums": [
                 {"code": "TV", "name": "IHM_ENUM_TV"},
                 {"code": "RADIO", "name": "IHM_ENUM_RADIO"},
@@ -816,18 +772,31 @@ final dynamic samplePolioInsideHouseholdMonitoringFlows = {
                 {"code": "NEWSPAPER", "name": "IHM_ENUM_NEWSPAPER"},
                 {"code": "OTHERS", "name": "IHM_ENUM_OTHERS_SOURCE"}
               ],
+              "label": "IHM_CAMPAIGN_INFO_SOURCE_LABEL",
+              "order": 23,
+              "value": "",
+              "format": "dropdown",
+              "hidden": false,
+              "tooltip": "",
+              "helpText": "",
+              "infoText": "",
+              "readOnly": false,
+              "fieldName": "campaignInfoSource",
+              "deleteFlag": false,
+              "innerLabel": "",
+              "systemDate": false,
+              "validations": [],
+              "errorMessage": "",
+              "isMultiSelect": true,
               "visibilityCondition": {
                 "expression": [
                   {
-                    "condition":
-                        "monitoringDetails.caregiverInformed=='YES'",
-                    "type": "custom"
+                    "type": "custom",
+                    "condition": "monitoringDetails.caregiverInformed=='YES'"
                   }
                 ]
               }
             },
-
-            // O. infoSourceOther
             {
               "type": "string",
               "label": "IHM_INFO_SOURCE_OTHER_LABEL",
@@ -849,17 +818,18 @@ final dynamic samplePolioInsideHouseholdMonitoringFlows = {
               "visibilityCondition": {
                 "expression": [
                   {
-                    "condition":
-                        "monitoringDetails.caregiverInformed=='YES'",
-                    "type": "custom"
+                    "type": "custom",
+                    "condition": "monitoringDetails.caregiverInformed=='YES'"
                   }
                 ]
               }
             },
-
-            // P. afpLimbWeakness
             {
               "type": "string",
+              "enums": [
+                {"code": "YES", "name": "IHM_ENUM_YES"},
+                {"code": "NO", "name": "IHM_ENUM_NO"}
+              ],
               "label": "IHM_AFP_LIMB_WEAKNESS_LABEL",
               "order": 25,
               "value": "",
@@ -880,15 +850,10 @@ final dynamic samplePolioInsideHouseholdMonitoringFlows = {
                   "message": "IHM_VALIDATION_REQUIRED"
                 }
               ],
-              "errorMessage": "",
-              "isMultiSelect": false,
-              "enums": [
-                {"code": "YES", "name": "IHM_ENUM_YES"},
-                {"code": "NO", "name": "IHM_ENUM_NO"}
-              ]
+              "errorMessage":
+                  "INSIDEMONITORING_INSIDEHOUSEHOLDENTRY_afpLimbWeakness_ERROR",
+              "isMultiSelect": false
             },
-
-            // afpSuddenWeakness (number of AFP cases)
             {
               "type": "integer",
               "label": "IHM_AFP_CASE_COUNT_LABEL",
@@ -912,22 +877,18 @@ final dynamic samplePolioInsideHouseholdMonitoringFlows = {
                   "message": "IHM_VALIDATION_MIN_ZERO"
                 }
               ],
-              "errorMessage": "",
+              "errorMessage":
+                  "INSIDEMONITORING_INSIDEHOUSEHOLDENTRY_afpSuddenWeakness_ERROR",
               "isMultiSelect": false,
               "visibilityCondition": {
                 "expression": [
                   {
-                    "condition":
-                        "monitoringDetails.afpLimbWeakness=='YES'",
-                    "type": "custom"
+                    "type": "custom",
+                    "condition": "monitoringDetails.afpLimbWeakness=='YES'"
                   }
                 ]
               }
             },
-
-            // ── Caregiver details ──
-
-            // caregiverName
             {
               "type": "string",
               "label": "IHM_CAREGIVER_NAME_LABEL",
@@ -950,11 +911,10 @@ final dynamic samplePolioInsideHouseholdMonitoringFlows = {
                   "message": "IHM_VALIDATION_REQUIRED"
                 }
               ],
-              "errorMessage": "",
+              "errorMessage":
+                  "INSIDEMONITORING_INSIDEHOUSEHOLDENTRY_caregiverName_ERROR",
               "isMultiSelect": false
             },
-
-            // caregiverPhone
             {
               "type": "string",
               "label": "IHM_CAREGIVER_PHONE_LABEL",
@@ -974,35 +934,32 @@ final dynamic samplePolioInsideHouseholdMonitoringFlows = {
               "errorMessage": "",
               "isMultiSelect": false
             }
-          ]
+          ],
+          "systemDate": null,
+          "actionLabel": "IHM_NEXT",
+          "description": "IHM_MONITORING_DETAILS_DESC",
+          "validations": null,
+          "includeInForm": null,
+          "isMultiSelect": null,
+          "includeInSummary": null
         },
-
-        // ── Page 3: Closeout (Last Household Location + Final observations) ──
         {
           "page": "closeout",
+          "type": "object",
           "label": "IHM_CLOSEOUT_LABEL",
           "order": 3,
-          "type": "object",
-          "description": "IHM_CLOSEOUT_DESC",
-          "actionLabel": "IHM_SUBMIT",
           "value": null,
-          "required": null,
           "hidden": null,
-          "helpText": null,
-          "innerLabel": null,
-          "validations": null,
-          "tooltip": null,
-          "startDate": null,
           "endDate": null,
+          "tooltip": null,
+          "helpText": null,
           "readOnly": null,
+          "required": null,
           "charCount": null,
-          "systemDate": null,
-          "isMultiSelect": null,
-          "includeInForm": null,
-          "includeInSummary": null,
+          "startDate": null,
           "autoEnable": null,
+          "innerLabel": null,
           "properties": [
-            // 1. gpsLastHousehold
             {
               "type": "string",
               "label": "IHM_GPS_LAST_HOUSEHOLD_LABEL",
@@ -1022,10 +979,12 @@ final dynamic samplePolioInsideHouseholdMonitoringFlows = {
               "errorMessage": "",
               "isMultiSelect": false
             },
-
-            // 2. poorlyCoveredAreas
             {
               "type": "string",
+              "enums": [
+                {"code": "YES", "name": "IHM_ENUM_YES"},
+                {"code": "NO", "name": "IHM_ENUM_NO"}
+              ],
               "label": "IHM_POORLY_COVERED_AREAS_LABEL",
               "order": 2,
               "value": "",
@@ -1046,15 +1005,10 @@ final dynamic samplePolioInsideHouseholdMonitoringFlows = {
                   "message": "IHM_VALIDATION_REQUIRED"
                 }
               ],
-              "errorMessage": "",
-              "isMultiSelect": false,
-              "enums": [
-                {"code": "YES", "name": "IHM_ENUM_YES"},
-                {"code": "NO", "name": "IHM_ENUM_NO"}
-              ]
+              "errorMessage":
+                  "INSIDEMONITORING_INSIDEHOUSEHOLDENTRY_poorlyCoveredAreas_ERROR",
+              "isMultiSelect": false
             },
-
-            // 3. finalComments
             {
               "type": "string",
               "label": "IHM_FINAL_COMMENTS_LABEL",
@@ -1077,24 +1031,35 @@ final dynamic samplePolioInsideHouseholdMonitoringFlows = {
                   "message": "IHM_VALIDATION_MAX_500"
                 }
               ],
-              "errorMessage": "",
+              "errorMessage":
+                  "INSIDEMONITORING_INSIDEHOUSEHOLDENTRY_finalComments_ERROR",
               "isMultiSelect": false
             }
-          ]
+          ],
+          "systemDate": null,
+          "actionLabel": "IHM_SUBMIT",
+          "description": "IHM_CLOSEOUT_DESC",
+          "validations": null,
+          "includeInForm": null,
+          "isMultiSelect": null,
+          "includeInSummary": null
         }
       ],
+      "version": 1,
+      "category": "Monitoring",
+      "disabled": false,
       "onAction": [
         {
           "actionType": "FETCH_TRANSFORMER_CONFIG",
           "properties": {
-            "configName": "polioInsideHousehold",
             "data": [],
             "onError": [
               {
                 "actionType": "SHOW_TOAST",
                 "properties": {"message": "IHM_ERROR_FETCH_CONFIG"}
               }
-            ]
+            ],
+            "configName": "polioInsideHousehold"
           }
         },
         {
@@ -1129,74 +1094,20 @@ final dynamic samplePolioInsideHouseholdMonitoringFlows = {
             ]
           }
         }
-      ]
-    },
-
-    // ══════════════════════════════════════════════════════════════════════
-    // Flow 2: insideMonitoringSummary (TEMPLATE) — Summary of recorded data
-    // ══════════════════════════════════════════════════════════════════════
-    {
-      "screenType": "TEMPLATE",
-      "name": "insideMonitoringSummary",
-      "order": 2,
-      "canPop": false,
-      "heading": "IHM_SUMMARY_HEADING",
-      "description": "IHM_SUMMARY_DESCRIPTION",
-      "header": [],
-      "initActions": [
-        {
-          "actionType": "SEARCH_EVENT",
-          "properties": {
-            "data": [
-              {
-                "key": "clientReferenceId",
-                "value": "{{navigation.SessionClientReferenceId}}",
-                "operation": "equals",
-                "root": "userAction"
-              }
-            ],
-            "name": "session",
-            "type": "SEARCH_EVENT"
-          }
-        }
       ],
-      "wrapperConfig": {
-        "filters": [
-          {"field": "action", "equals": "LOCATION_CAPTURE"},
-          {
-            "field": "additionalFields.form",
-            "equals": "POLIO_INSIDE_MONITORING"
-          }
-        ],
-        "relations": [
-          {
-            "name": "session",
-            "match": {
-              "field": "clientReferenceId",
-              "equalsFrom": "clientReferenceId"
-            },
-            "entity": "UserActionModel"
-          }
-        ],
-        "rootEntity": "UserActionModel",
-        "wrapperName": "InsideMonitoringWrapper",
-        "searchConfig": {
-          "select": ["userAction"],
-          "primary": "userAction"
-        }
-      },
+      "isSelected": true,
+      "screenType": "FORM",
+      "initActions": [],
+      "wrapperConfig": {},
+      "includeSummary": true
+    },
+    {
       "body": [
-        // ── Summary card with labelPairList ──
         {
           "type": "template",
           "format": "card",
-          "fieldName": "summaryCard",
-          "properties": {"type": "primary"},
           "children": [
             {
-              "type": "template",
-              "format": "labelPairList",
-              "fieldName": "sessionSummary",
               "data": [
                 {
                   "key": "IHM_SUMMARY_MONITOR_NAME",
@@ -1294,26 +1205,31 @@ final dynamic samplePolioInsideHouseholdMonitoringFlows = {
                       "{{contextData.0.session.UserActionModel.additionalFields.fields.finalComments}}",
                   "isActive": true
                 }
-              ]
+              ],
+              "type": "template",
+              "format": "labelPairList",
+              "fieldName": "sessionSummary"
             }
-          ]
+          ],
+          "fieldName": "summaryCard",
+          "properties": {"type": "primary"}
         }
       ],
+      "name": "insideMonitoringSummary",
+      "order": 2,
+      "canPop": false,
       "footer": [
         {
           "type": "template",
-          "format": "button",
           "label": "IHM_ADD_ANOTHER_SESSION",
-          "fieldName": "addAnotherSession",
+          "format": "button",
           "onAction": [
             {
               "actionType": "NAVIGATION",
-              "properties": {
-                "type": "FORM",
-                "name": "insideHouseholdEntry"
-              }
+              "properties": {"name": "insideHouseholdEntry", "type": "FORM"}
             }
           ],
+          "fieldName": "addAnotherSession",
           "properties": {
             "size": "large",
             "type": "secondary",
@@ -1323,15 +1239,15 @@ final dynamic samplePolioInsideHouseholdMonitoringFlows = {
         },
         {
           "type": "template",
-          "format": "button",
           "label": "IHM_BACK_TO_HOME",
-          "fieldName": "backToHome",
+          "format": "button",
           "onAction": [
             {
               "actionType": "BACK_NAVIGATION",
               "properties": {"name": "HOME", "type": "HOME"}
             }
           ],
+          "fieldName": "backToHome",
           "properties": {
             "size": "large",
             "type": "primary",
@@ -1339,7 +1255,54 @@ final dynamic samplePolioInsideHouseholdMonitoringFlows = {
             "mainAxisAlignment": "center"
           }
         }
-      ]
+      ],
+      "header": [],
+      "heading": "IHM_SUMMARY_HEADING",
+      "category": "Monitoring",
+      "screenType": "TEMPLATE",
+      "description": "IHM_SUMMARY_DESCRIPTION",
+      "initActions": [
+        {
+          "actionType": "SEARCH_EVENT",
+          "properties": {
+            "data": [
+              {
+                "key": "clientReferenceId",
+                "root": "userAction",
+                "value": "{{navigation.SessionClientReferenceId}}",
+                "operation": "equals"
+              }
+            ],
+            "name": "session",
+            "type": "SEARCH_EVENT"
+          }
+        }
+      ],
+      "wrapperConfig": {
+        "filters": [
+          {"field": "action", "equals": "LOCATION_CAPTURE"},
+          {
+            "field": "additionalFields.form",
+            "equals": "POLIO_INSIDE_MONITORING"
+          }
+        ],
+        "relations": [
+          {
+            "name": "session",
+            "match": {
+              "field": "clientReferenceId",
+              "equalsFrom": "clientReferenceId"
+            },
+            "entity": "UserActionModel"
+          }
+        ],
+        "rootEntity": "UserActionModel",
+        "wrapperName": "InsideMonitoringWrapper",
+        "searchConfig": {
+          "select": ["userAction"],
+          "primary": "userAction"
+        }
+      }
     }
   ]
 };

--- a/apps/health_campaign_field_worker_app/lib/sampleJsonConfigs/polio_lqa_data_collection.dart
+++ b/apps/health_campaign_field_worker_app/lib/sampleJsonConfigs/polio_lqa_data_collection.dart
@@ -6,11 +6,9 @@ final dynamic samplePolioLqaDataCollectionFlows = {
   "disabled": false,
   "isSelected": true,
   "flows": [
-    // ════════════════════════════════════════════════════════════════════════
-    // Flow 1: lqaClusterEntry (FORM) — Cluster info page
-    // ════════════════════════════════════════════════════════════════════════
     {
       "name": "lqaClusterEntry",
+      "order": 1,
       "pages": [
         {
           "page": "clusterInfo",
@@ -34,7 +32,7 @@ final dynamic samplePolioLqaDataCollectionFlows = {
               "label": "LQA_SURVEY_DATE_LABEL",
               "order": 1,
               "value": "",
-              "format": "text",
+              "format": "date",
               "hidden": false,
               "tooltip": "",
               "helpText": "",
@@ -51,7 +49,7 @@ final dynamic samplePolioLqaDataCollectionFlows = {
                   "message": "LQA_VALIDATION_SURVEY_DATE_REQUIRED"
                 }
               ],
-              "errorMessage": "",
+              "errorMessage": "LQA_LQACLUSTERENTRY_surveyDate_ERROR",
               "isMultiSelect": false
             },
             {
@@ -66,25 +64,6 @@ final dynamic samplePolioLqaDataCollectionFlows = {
               "infoText": "",
               "readOnly": true,
               "fieldName": "settlementArea",
-              "deleteFlag": false,
-              "innerLabel": "",
-              "systemDate": false,
-              "validations": [],
-              "errorMessage": "",
-              "isMultiSelect": false
-            },
-            {
-              "type": "string",
-              "label": "LQA_HEALTH_FACILITY_AREA_LABEL",
-              "order": 3,
-              "value": "",
-              "format": "text",
-              "hidden": false,
-              "tooltip": "",
-              "helpText": "",
-              "infoText": "",
-              "readOnly": false,
-              "fieldName": "healthFacilityArea",
               "deleteFlag": false,
               "innerLabel": "",
               "systemDate": false,
@@ -114,7 +93,7 @@ final dynamic samplePolioLqaDataCollectionFlows = {
                   "message": "LQA_VALIDATION_LOT_NUMBER_REQUIRED"
                 }
               ],
-              "errorMessage": "",
+              "errorMessage": "LQA_LQACLUSTERENTRY_lotNumber_ERROR",
               "isMultiSelect": false
             },
             {
@@ -147,7 +126,7 @@ final dynamic samplePolioLqaDataCollectionFlows = {
                   "message": "LQA_VALIDATION_CLUSTER_NUMBER_REQUIRED"
                 }
               ],
-              "errorMessage": "",
+              "errorMessage": "LQA_LQACLUSTERENTRY_clusterNumber_ERROR",
               "isMultiSelect": false
             },
             {
@@ -170,9 +149,14 @@ final dynamic samplePolioLqaDataCollectionFlows = {
                   "type": "required",
                   "value": true,
                   "message": "LQA_VALIDATION_SURVEYOR_NAME_REQUIRED"
+                },
+                {
+                  "type": "pattern",
+                  "value": "^[a-zA-Z0-9 ]+\$",
+                  "message": "VALIDATION_ALPHANUMERIC_ONLY"
                 }
               ],
-              "errorMessage": "",
+              "errorMessage": "LQA_LQACLUSTERENTRY_surveyorName_ERROR",
               "isMultiSelect": false,
               "autoFillCondition": [
                 {"value": "{{loggedInUserName}}", "expression": "true==true"}
@@ -200,7 +184,7 @@ final dynamic samplePolioLqaDataCollectionFlows = {
                   "message": "LQA_VALIDATION_PHONE_REQUIRED"
                 }
               ],
-              "errorMessage": "",
+              "errorMessage": "LQA_LQACLUSTERENTRY_surveyorPhone_ERROR",
               "isMultiSelect": false,
               "autoFillCondition": [
                 {
@@ -216,6 +200,7 @@ final dynamic samplePolioLqaDataCollectionFlows = {
               "value": "",
               "format": "text",
               "hidden": false,
+              "pattern": "^[a-zA-Z0-9 ]+\$",
               "tooltip": "",
               "helpText": "",
               "infoText": "",
@@ -231,37 +216,17 @@ final dynamic samplePolioLqaDataCollectionFlows = {
                   "message": "LQA_VALIDATION_COORDINATOR_NAME_REQUIRED"
                 },
                 {
+                  "type": "pattern",
+                  "value": "^[a-zA-Z0-9 ]+\$",
+                  "message": "VALIDATION_ALPHANUMERIC_ONLY"
+                },
+                {
                   "type": "minLength",
                   "value": 2,
                   "message": "LQA_VALIDATION_NAME_MIN_2_CHARS"
                 }
               ],
-              "errorMessage": "",
-              "isMultiSelect": false
-            },
-            {
-              "type": "string",
-              "label": "LQA_STARTING_VILLAGE_LABEL",
-              "order": 9,
-              "value": "",
-              "format": "text",
-              "hidden": false,
-              "tooltip": "",
-              "helpText": "",
-              "infoText": "",
-              "readOnly": false,
-              "fieldName": "startingVillage",
-              "deleteFlag": false,
-              "innerLabel": "",
-              "systemDate": false,
-              "validations": [
-                {
-                  "type": "required",
-                  "value": true,
-                  "message": "LQA_VALIDATION_STARTING_VILLAGE_REQUIRED"
-                }
-              ],
-              "errorMessage": "",
+              "errorMessage": "LQA_LQACLUSTERENTRY_lqasCoordinatorName_ERROR",
               "isMultiSelect": false
             },
             {
@@ -291,7 +256,7 @@ final dynamic samplePolioLqaDataCollectionFlows = {
               "tooltip": "",
               "helpText": "",
               "infoText": "",
-              "readOnly": true,
+              "readOnly": false,
               "fieldName": "settlementType",
               "deleteFlag": false,
               "innerLabel": "",
@@ -303,7 +268,7 @@ final dynamic samplePolioLqaDataCollectionFlows = {
                   "message": "LQA_VALIDATION_SETTLEMENT_TYPE_REQUIRED"
                 }
               ],
-              "errorMessage": "",
+              "errorMessage": "LQA_LQACLUSTERENTRY_settlementType_ERROR",
               "isMultiSelect": false,
               "autoFillCondition": [
                 {
@@ -338,7 +303,7 @@ final dynamic samplePolioLqaDataCollectionFlows = {
                   "message": "LQA_VALIDATION_REQUIRED"
                 }
               ],
-              "errorMessage": "",
+              "errorMessage": "LQA_LQACLUSTERENTRY_settlementSmall_ERROR",
               "isMultiSelect": false
             },
             {
@@ -363,7 +328,7 @@ final dynamic samplePolioLqaDataCollectionFlows = {
                   "message": "LQA_VALIDATION_GPS_REQUIRED"
                 }
               ],
-              "errorMessage": "",
+              "errorMessage": "LQA_LQACLUSTERENTRY_gpsStart_ERROR",
               "isMultiSelect": false
             }
           ],
@@ -376,8 +341,8 @@ final dynamic samplePolioLqaDataCollectionFlows = {
           "includeInSummary": null
         }
       ],
-      "project": "POLIO-SIA",
       "version": 1,
+      "category": "LQA",
       "disabled": false,
       "onAction": [
         {
@@ -431,13 +396,8 @@ final dynamic samplePolioLqaDataCollectionFlows = {
       "initActions": [],
       "wrapperConfig": {}
     },
-
-    // ════════════════════════════════════════════════════════════════════════
-    // Flow 2: clusterOverview (TEMPLATE) — Shows cluster details + children
-    // ════════════════════════════════════════════════════════════════════════
     {
       "body": [
-        // ── Cluster details card ──
         {
           "type": "template",
           "format": "card",
@@ -473,12 +433,6 @@ final dynamic samplePolioLqaDataCollectionFlows = {
                   "value":
                       "{{contextData.0.cluster.UserActionModel.additionalFields.fields.surveyorName}}",
                   "isActive": true
-                },
-                {
-                  "key": "LQA_SETTLEMENT_TYPE_LABEL",
-                  "value":
-                      "{{contextData.0.cluster.UserActionModel.additionalFields.fields.settlementType}}",
-                  "isActive": true
                 }
               ],
               "type": "template",
@@ -489,8 +443,6 @@ final dynamic samplePolioLqaDataCollectionFlows = {
           "fieldName": "clusterCard",
           "properties": {"type": "primary"}
         },
-
-        // ── Children listView with memberCard ──
         {
           "type": "template",
           "child": {
@@ -498,237 +450,107 @@ final dynamic samplePolioLqaDataCollectionFlows = {
             "format": "card",
             "children": [
               {
-                "type": "template",
-                "value":
-                    "{{ item.child.0.additionalFields.fields.fingerMarked }}",
-                "format": "tag",
-                "visible":
-                    "{{ item.child.0.additionalFields.fields.fingerMarked }}!=null",
-                "fieldName": "fingerMarkedTag",
-                "properties": {
-                  "tagType": "status",
-                  "bottomGap": 8,
-                  "tagMapping": {
-                    "YES": {
-                      "label": "LQA_TAG_FINGER_MARKED",
-                      "type": "success"
-                    },
-                    "NO": {"label": "LQA_TAG_NOT_MARKED", "type": "error"}
-                  }
-                }
-              },
-              {
-                "type": "template",
-                "format": "row",
-                "properties": {"bottomGap": 8},
-                "children": [
+                "data": [
                   {
-                    "type": "template",
+                    "key": "LQA_CHILDREN_UNDER_5_LABEL",
                     "value":
-                        "{{ item.child.0.additionalFields.fields.childAgeMonths }} months | {{ item.child.0.additionalFields.fields.childSex }}",
-                    "format": "textTemplate",
-                    "fieldName": "childAgeSex"
-                  }
-                ]
-              },
-              {
-                "type": "template",
-                "format": "row",
-                "properties": {"bottomGap": 8},
-                "children": [
+                        "{{ item.child.0.additionalFields.fields.childrenUnder5 }}",
+                    "isActive": true
+                  },
                   {
-                    "type": "template",
+                    "key": "LQA_CHILD_AGE_MONTHS_LABEL",
                     "value":
-                        "Children Under 5: {{ item.child.0.additionalFields.fields.childrenUnder5 }}",
-                    "format": "textTemplate",
-                    "fieldName": "childrenUnder5"
-                  }
-                ]
-              },
-              {
-                "type": "template",
-                "format": "row",
-                "properties": {"bottomGap": 8},
-                "visible":
-                    "{{ item.child.0.additionalFields.fields.reasonNotMarked }}!=null",
-                "children": [
+                        "{{ item.child.0.additionalFields.fields.childAgeMonths }}",
+                    "isActive": true
+                  },
                   {
-                    "type": "template",
+                    "key": "LQA_CHILD_SEX_LABEL",
                     "value":
-                        "Reason Not Marked: {{ item.child.0.additionalFields.fields.reasonNotMarked }}",
-                    "format": "textTemplate",
-                    "fieldName": "reasonNotMarked"
-                  }
-                ]
-              },
-              {
-                "type": "template",
-                "format": "row",
-                "properties": {"bottomGap": 8},
-                "visible":
-                    "{{ item.child.0.additionalFields.fields.reasonNotMarkedOther }}!=null",
-                "children": [
+                        "{{ item.child.0.additionalFields.fields.childSex }}",
+                    "isActive": true
+                  },
                   {
-                    "type": "template",
+                    "key": "LQA_FINGER_MARKED_LABEL",
                     "value":
-                        "Other Reason: {{ item.child.0.additionalFields.fields.reasonNotMarkedOther }}",
-                    "format": "textTemplate",
-                    "fieldName": "reasonNotMarkedOther"
-                  }
-                ]
-              },
-              {
-                "type": "template",
-                "format": "row",
-                "properties": {"bottomGap": 8},
-                "visible":
-                    "{{ item.child.0.additionalFields.fields.refusalReason }}!=null",
-                "children": [
+                        "{{ item.child.0.additionalFields.fields.fingerMarked }}",
+                    "isActive": true
+                  },
                   {
-                    "type": "template",
+                    "key": "LQA_REASON_NOT_MARKED_LABEL",
                     "value":
-                        "Refusal Reason: {{ item.child.0.additionalFields.fields.refusalReason }}",
-                    "format": "textTemplate",
-                    "fieldName": "refusalReason"
-                  }
-                ]
-              },
-              {
-                "type": "template",
-                "format": "row",
-                "properties": {"bottomGap": 8},
-                "visible":
-                    "{{ item.child.0.additionalFields.fields.refusalReasonOther }}!=null",
-                "children": [
+                        "{{ item.child.0.additionalFields.fields.reasonNotMarked }}",
+                    "isActive": true
+                  },
                   {
-                    "type": "template",
+                    "key": "LQA_OTHER_REASON_SPECIFY_LABEL",
                     "value":
-                        "Other Refusal: {{ item.child.0.additionalFields.fields.refusalReasonOther }}",
-                    "format": "textTemplate",
-                    "fieldName": "refusalReasonOther"
-                  }
-                ]
-              },
-              {
-                "type": "template",
-                "format": "row",
-                "properties": {"bottomGap": 8},
-                "visible":
-                    "{{ item.child.0.additionalFields.fields.absenceReason }}!=null",
-                "children": [
+                        "{{ item.child.0.additionalFields.fields.reasonNotMarkedOther }}",
+                    "isActive": true
+                  },
                   {
-                    "type": "template",
+                    "key": "LQA_REFUSAL_REASON_LABEL",
                     "value":
-                        "Absence Reason: {{ item.child.0.additionalFields.fields.absenceReason }}",
-                    "format": "textTemplate",
-                    "fieldName": "absenceReason"
-                  }
-                ]
-              },
-              {
-                "type": "template",
-                "format": "row",
-                "properties": {"bottomGap": 8},
-                "visible":
-                    "{{ item.child.0.additionalFields.fields.absenceReasonOther }}!=null",
-                "children": [
+                        "{{ item.child.0.additionalFields.fields.refusalReason }}",
+                    "isActive": true
+                  },
                   {
-                    "type": "template",
+                    "key": "LQA_OTHER_REFUSAL_REASON_LABEL",
                     "value":
-                        "Other Absence: {{ item.child.0.additionalFields.fields.absenceReasonOther }}",
-                    "format": "textTemplate",
-                    "fieldName": "absenceReasonOther"
-                  }
-                ]
-              },
-              {
-                "type": "template",
-                "format": "row",
-                "properties": {"bottomGap": 8},
-                "children": [
+                        "{{ item.child.0.additionalFields.fields.refusalReasonOther }}",
+                    "isActive": true
+                  },
                   {
-                    "type": "template",
+                    "key": "LQA_ABSENCE_REASON_LABEL",
                     "value":
-                        "Caregiver Informed: {{ item.child.0.additionalFields.fields.caregiverInformed }}",
-                    "format": "textTemplate",
-                    "fieldName": "caregiverInformed"
-                  }
-                ]
-              },
-              {
-                "type": "template",
-                "format": "row",
-                "properties": {"bottomGap": 8},
-                "visible":
-                    "{{ item.child.0.additionalFields.fields.campaignAwareness }}!=null",
-                "children": [
+                        "{{ item.child.0.additionalFields.fields.absenceReason }}",
+                    "isActive": true
+                  },
                   {
-                    "type": "template",
+                    "key": "LQA_OTHER_ABSENCE_REASON_LABEL",
                     "value":
-                        "Campaign Awareness: {{ item.child.0.additionalFields.fields.campaignAwareness }}",
-                    "format": "textTemplate",
-                    "fieldName": "campaignAwareness"
-                  }
-                ]
-              },
-              {
-                "type": "template",
-                "format": "row",
-                "properties": {"bottomGap": 8},
-                "visible":
-                    "{{ item.child.0.additionalFields.fields.awarenessOther }}!=null",
-                "children": [
+                        "{{ item.child.0.additionalFields.fields.absenceReasonOther }}",
+                    "isActive": true
+                  },
                   {
-                    "type": "template",
+                    "key": "LQA_CAREGIVER_INFORMED_LABEL",
                     "value":
-                        "Other Awareness: {{ item.child.0.additionalFields.fields.awarenessOther }}",
-                    "format": "textTemplate",
-                    "fieldName": "awarenessOther"
-                  }
-                ]
-              },
-              {
-                "type": "template",
-                "format": "row",
-                "properties": {"bottomGap": 8},
-                "children": [
+                        "{{ item.child.0.additionalFields.fields.caregiverInformed }}",
+                    "isActive": true
+                  },
                   {
-                    "type": "template",
+                    "key": "LQA_CAMPAIGN_AWARENESS_LABEL",
                     "value":
-                        "OPV Doses From Birth: {{ item.child.0.additionalFields.fields.opvDosesFromBirth }}",
-                    "format": "textTemplate",
-                    "fieldName": "opvDosesFromBirth"
-                  }
-                ]
-              },
-              {
-                "type": "template",
-                "format": "row",
-                "properties": {"bottomGap": 8},
-                "children": [
+                        "{{ item.child.0.additionalFields.fields.campaignAwareness }}",
+                    "isActive": true
+                  },
                   {
-                    "type": "template",
+                    "key": "LQA_AWARENESS_OTHER_LABEL",
                     "value":
-                        "AFP Awareness: {{ item.child.0.additionalFields.fields.afpAwareness }}",
-                    "format": "textTemplate",
-                    "fieldName": "afpAwareness"
-                  }
-                ]
-              },
-              {
-                "type": "template",
-                "format": "row",
-                "visible":
-                    "{{ item.child.0.additionalFields.fields.afpCaseCount }}!=null",
-                "children": [
+                        "{{ item.child.0.additionalFields.fields.awarenessOther }}",
+                    "isActive": true
+                  },
                   {
-                    "type": "template",
+                    "key": "LQA_OPV_DOSES_LABEL",
                     "value":
-                        "AFP Case Count: {{ item.child.0.additionalFields.fields.afpCaseCount }}",
-                    "format": "textTemplate",
-                    "fieldName": "afpCaseCount"
+                        "{{ item.child.0.additionalFields.fields.opvDosesFromBirth }}",
+                    "isActive": true
+                  },
+                  {
+                    "key": "LQA_AFP_AWARENESS_LABEL",
+                    "value":
+                        "{{ item.child.0.additionalFields.fields.afpAwareness }}",
+                    "isActive": true
+                  },
+                  {
+                    "key": "LQA_AFP_CASE_COUNT_LABEL",
+                    "value":
+                        "{{ item.child.0.additionalFields.fields.afpCaseCount }}",
+                    "isActive": true
                   }
-                ]
+                ],
+                "type": "template",
+                "format": "labelPairList",
+                "fieldName": "childDetails"
               }
             ],
             "fieldName": "childCard",
@@ -743,8 +565,6 @@ final dynamic samplePolioLqaDataCollectionFlows = {
           "dataSource": "children",
           "properties": {"spacing": "spacer4"}
         },
-
-        // ── "Add Child Details" button ──
         {
           "type": "template",
           "label": "LQA_ADD_CHILD_BUTTON",
@@ -808,6 +628,7 @@ final dynamic samplePolioLqaDataCollectionFlows = {
       ],
       "header": [],
       "heading": "LQA_CLUSTER_OVERVIEW_HEADING",
+      "category": "LQA",
       "screenType": "TEMPLATE",
       "description": "LQA_CLUSTER_OVERVIEW_DESCRIPTION",
       "initActions": [
@@ -817,9 +638,9 @@ final dynamic samplePolioLqaDataCollectionFlows = {
             "data": [
               {
                 "key": "resourceTag",
+                "root": "userAction",
                 "value": "{{navigation.ClusterClientReferenceId}}",
-                "operation": "equals",
-                "root": "userAction"
+                "operation": "equals"
               }
             ],
             "name": "cluster",
@@ -871,12 +692,9 @@ final dynamic samplePolioLqaDataCollectionFlows = {
         }
       }
     },
-
-    // ════════════════════════════════════════════════════════════════════════
-    // Flow 3: ADD_LQA_CHILD (FORM) — Add a single child interview
-    // ════════════════════════════════════════════════════════════════════════
     {
       "name": "ADD_LQA_CHILD",
+      "order": 3,
       "pages": [
         {
           "page": "childDetails",
@@ -923,7 +741,7 @@ final dynamic samplePolioLqaDataCollectionFlows = {
                   "message": "LQA_VALIDATION_MIN_ZERO"
                 }
               ],
-              "errorMessage": "",
+              "errorMessage": "LQA_ADD_LQA_CHILD_childrenUnder5_ERROR",
               "isMultiSelect": false
             },
             {
@@ -959,7 +777,7 @@ final dynamic samplePolioLqaDataCollectionFlows = {
                   "message": "LQA_VALIDATION_MAX_59_MONTHS"
                 }
               ],
-              "errorMessage": "",
+              "errorMessage": "LQA_ADD_LQA_CHILD_childAgeMonths_ERROR",
               "isMultiSelect": false
             },
             {
@@ -988,7 +806,7 @@ final dynamic samplePolioLqaDataCollectionFlows = {
                   "message": "LQA_VALIDATION_REQUIRED"
                 }
               ],
-              "errorMessage": "",
+              "errorMessage": "LQA_ADD_LQA_CHILD_childSex_ERROR",
               "isMultiSelect": false
             },
             {
@@ -1017,7 +835,7 @@ final dynamic samplePolioLqaDataCollectionFlows = {
                   "message": "LQA_VALIDATION_REQUIRED"
                 }
               ],
-              "errorMessage": "",
+              "errorMessage": "LQA_ADD_LQA_CHILD_fingerMarked_ERROR",
               "isMultiSelect": false
             },
             {
@@ -1069,6 +887,7 @@ final dynamic samplePolioLqaDataCollectionFlows = {
               "value": "",
               "format": "text",
               "hidden": false,
+              "pattern": "^[a-zA-Z0-9 ]+\$",
               "tooltip": "",
               "helpText": "",
               "infoText": "",
@@ -1077,8 +896,14 @@ final dynamic samplePolioLqaDataCollectionFlows = {
               "deleteFlag": false,
               "innerLabel": "",
               "systemDate": false,
-              "validations": [],
-              "errorMessage": "",
+              "validations": [
+                {
+                  "type": "pattern",
+                  "value": "^[a-zA-Z0-9 ]+\$",
+                  "message": "VALIDATION_ALPHANUMERIC_ONLY"
+                }
+              ],
+              "errorMessage": "LQA_ADD_LQA_CHILD_reasonNotMarkedOther_ERROR",
               "isMultiSelect": false,
               "visibilityCondition": {
                 "expression": [
@@ -1134,6 +959,7 @@ final dynamic samplePolioLqaDataCollectionFlows = {
               "visibilityCondition": {
                 "expression": [
                   {
+                    "type": "custom",
                     "condition":
                         "childDetails.reasonNotMarked=='NON_COMPLIANCE'"
                   }
@@ -1147,6 +973,7 @@ final dynamic samplePolioLqaDataCollectionFlows = {
               "value": "",
               "format": "text",
               "hidden": false,
+              "pattern": "^[a-zA-Z0-9 ]+\$",
               "tooltip": "",
               "helpText": "",
               "infoText": "",
@@ -1155,8 +982,14 @@ final dynamic samplePolioLqaDataCollectionFlows = {
               "deleteFlag": false,
               "innerLabel": "",
               "systemDate": false,
-              "validations": [],
-              "errorMessage": "",
+              "validations": [
+                {
+                  "type": "pattern",
+                  "value": "^[a-zA-Z0-9 ]+\$",
+                  "message": "VALIDATION_ALPHANUMERIC_ONLY"
+                }
+              ],
+              "errorMessage": "LQA_ADD_LQA_CHILD_refusalReasonOther_ERROR",
               "isMultiSelect": false,
               "visibilityCondition": {
                 "expression": [
@@ -1209,6 +1042,7 @@ final dynamic samplePolioLqaDataCollectionFlows = {
               "value": "",
               "format": "text",
               "hidden": false,
+              "pattern": "^[a-zA-Z0-9 ]+\$",
               "tooltip": "",
               "helpText": "",
               "infoText": "",
@@ -1217,8 +1051,14 @@ final dynamic samplePolioLqaDataCollectionFlows = {
               "deleteFlag": false,
               "innerLabel": "",
               "systemDate": false,
-              "validations": [],
-              "errorMessage": "",
+              "validations": [
+                {
+                  "type": "pattern",
+                  "value": "^[a-zA-Z0-9 ]+\$",
+                  "message": "VALIDATION_ALPHANUMERIC_ONLY"
+                }
+              ],
+              "errorMessage": "LQA_ADD_LQA_CHILD_absenceReasonOther_ERROR",
               "isMultiSelect": false,
               "visibilityCondition": {
                 "expression": [
@@ -1255,7 +1095,7 @@ final dynamic samplePolioLqaDataCollectionFlows = {
                   "message": "LQA_VALIDATION_REQUIRED"
                 }
               ],
-              "errorMessage": "",
+              "errorMessage": "LQA_ADD_LQA_CHILD_caregiverInformed_ERROR",
               "isMultiSelect": false
             },
             {
@@ -1365,7 +1205,7 @@ final dynamic samplePolioLqaDataCollectionFlows = {
                   "message": "LQA_VALIDATION_MIN_ZERO"
                 }
               ],
-              "errorMessage": "",
+              "errorMessage": "LQA_ADD_LQA_CHILD_opvDosesFromBirth_ERROR",
               "isMultiSelect": false
             },
             {
@@ -1394,7 +1234,7 @@ final dynamic samplePolioLqaDataCollectionFlows = {
                   "message": "LQA_VALIDATION_REQUIRED"
                 }
               ],
-              "errorMessage": "",
+              "errorMessage": "LQA_ADD_LQA_CHILD_afpAwareness_ERROR",
               "isMultiSelect": false
             },
             {
@@ -1420,7 +1260,7 @@ final dynamic samplePolioLqaDataCollectionFlows = {
                   "message": "LQA_VALIDATION_MIN_ZERO"
                 }
               ],
-              "errorMessage": "",
+              "errorMessage": "LQA_ADD_LQA_CHILD_afpCaseCount_ERROR",
               "isMultiSelect": false,
               "visibilityCondition": {
                 "expression": [
@@ -1441,8 +1281,8 @@ final dynamic samplePolioLqaDataCollectionFlows = {
           "includeInSummary": null
         }
       ],
-      "project": "POLIO-SIA",
       "version": 1,
+      "category": "LQA",
       "disabled": false,
       "onAction": [
         {
@@ -1486,14 +1326,14 @@ final dynamic samplePolioLqaDataCollectionFlows = {
             ],
             "name": "clusterOverview",
             "type": "TEMPLATE",
-            "navigationMode": "popUntilAndPush",
-            "popUntilPageName": "lqaClusterEntry",
             "onError": [
               {
                 "actionType": "SHOW_TOAST",
                 "properties": {"message": "LQA_ERROR_NAVIGATION"}
               }
-            ]
+            ],
+            "navigationMode": "popUntilAndPush",
+            "popUntilPageName": "lqaClusterEntry"
           }
         }
       ],
@@ -1502,12 +1342,9 @@ final dynamic samplePolioLqaDataCollectionFlows = {
       "initActions": [],
       "wrapperConfig": {}
     },
-
-    // ════════════════════════════════════════════════════════════════════════
-    // Flow 4: lqaCloseout (FORM) — GPS final + comments
-    // ════════════════════════════════════════════════════════════════════════
     {
       "name": "lqaCloseout",
+      "order": 4,
       "pages": [
         {
           "page": "closeout",
@@ -1567,7 +1404,7 @@ final dynamic samplePolioLqaDataCollectionFlows = {
                   "message": "LQA_VALIDATION_MAX_500_CHARS"
                 }
               ],
-              "errorMessage": "",
+              "errorMessage": "LQA_LQACLOSEOUT_finalComments_ERROR",
               "isMultiSelect": false
             }
           ],
@@ -1580,8 +1417,8 @@ final dynamic samplePolioLqaDataCollectionFlows = {
           "includeInSummary": null
         }
       ],
-      "project": "POLIO-SIA",
       "version": 1,
+      "category": "LQA",
       "disabled": false,
       "onAction": [
         {
@@ -1633,16 +1470,13 @@ final dynamic samplePolioLqaDataCollectionFlows = {
       "initActions": [],
       "wrapperConfig": {}
     },
-
-    // ════════════════════════════════════════════════════════════════════════
-    // Flow 5: lqaSuccess (TEMPLATE) — Success screen
-    // ════════════════════════════════════════════════════════════════════════
     {
       "body": [
         {
           "type": "template",
           "label": "LQA_SUCCESS_HEADING",
           "format": "panelCard",
+          "fieldName": "lqaSuccessHeading",
           "properties": {"type": "success"},
           "description": "LQA_SUCCESS_DESCRIPTION",
           "primaryAction": {
@@ -1679,6 +1513,7 @@ final dynamic samplePolioLqaDataCollectionFlows = {
       "footer": [],
       "header": [],
       "heading": "",
+      "category": "LQA",
       "screenType": "TEMPLATE",
       "description": "",
       "initActions": []

--- a/apps/health_campaign_field_worker_app/lib/sampleJsonConfigs/registration_smc_flows.dart
+++ b/apps/health_campaign_field_worker_app/lib/sampleJsonConfigs/registration_smc_flows.dart
@@ -14,7 +14,9 @@ final dynamic sampleSMCFlows = {
           "heading": "DELIVERY_SUCCESSFUL_PANEL_CARD_HEADING",
           "fieldName": "successCard",
           "mandatory": true,
-          "properties": {"type": "success"},
+          "properties": {
+            "type": "success"
+          },
           "description": "DELIVERY_SUCCESSFUL_PANEL_CARD_DESC",
           "primaryAction": {
             "type": "template",
@@ -38,7 +40,9 @@ final dynamic sampleSMCFlows = {
             ],
             "fieldName": "viewHouseholdButton",
             "mandatory": true,
-            "properties": {"type": "primary"}
+            "properties": {
+              "type": "primary"
+            }
           },
           "secondaryAction": {
             "type": "template",
@@ -48,12 +52,17 @@ final dynamic sampleSMCFlows = {
             "onAction": [
               {
                 "actionType": "NAVIGATION",
-                "properties": {"name": "searchBeneficiary", "type": "TEMPLATE"}
+                "properties": {
+                  "name": "searchBeneficiary",
+                  "type": "TEMPLATE"
+                }
               }
             ],
             "fieldName": "goBack",
             "mandatory": true,
-            "properties": {"type": "secondary"}
+            "properties": {
+              "type": "secondary"
+            }
           },
           "primaryActionLabel": "VIEW_HOUSEHOLD_DETAILS",
           "secondaryActionLabel": "GO_BACK"
@@ -101,7 +110,9 @@ final dynamic sampleSMCFlows = {
           "heading": "REDOSE_SUCCESSFUL_PANEL_CARD_HEADING",
           "fieldName": "successCard",
           "mandatory": true,
-          "properties": {"type": "success"},
+          "properties": {
+            "type": "success"
+          },
           "description": "REDOSE_SUCCESSFUL_PANEL_CARD_DESC",
           "primaryAction": {
             "type": "template",
@@ -125,7 +136,9 @@ final dynamic sampleSMCFlows = {
             ],
             "fieldName": "viewHouseholdButton",
             "mandatory": true,
-            "properties": {"type": "primary"}
+            "properties": {
+              "type": "primary"
+            }
           },
           "secondaryAction": {
             "type": "template",
@@ -135,12 +148,17 @@ final dynamic sampleSMCFlows = {
             "onAction": [
               {
                 "actionType": "NAVIGATION",
-                "properties": {"name": "searchBeneficiary", "type": "TEMPLATE"}
+                "properties": {
+                  "name": "searchBeneficiary",
+                  "type": "TEMPLATE"
+                }
               }
             ],
             "fieldName": "goBack",
             "mandatory": true,
-            "properties": {"type": "secondary"}
+            "properties": {
+              "type": "secondary"
+            }
           },
           "primaryActionLabel": "VIEW_HOUSEHOLD_DETAILS",
           "secondaryActionLabel": "GO_BACK"
@@ -189,38 +207,31 @@ final dynamic sampleSMCFlows = {
               "data": [
                 {
                   "key": "NAME_OF_INDIVIDUAL",
-                  "value":
-                      "{{contextData.0.individuals.IndividualModel.name.givenName}}"
+                  "value": "{{contextData.0.individuals.IndividualModel.name.givenName}}"
                 },
                 {
                   "key": "ID_TYPE",
-                  "value":
-                      "{{contextData.0.individuals.IndividualModel.identifiers.0.identifierType}}"
+                  "value": "{{contextData.0.individuals.IndividualModel.identifiers.0.identifierType}}"
                 },
                 {
                   "key": "ID_NUMBER",
-                  "value":
-                      "{{contextData.0.individuals.IndividualModel.identifiers.0.identifierId}}"
+                  "value": "{{contextData.0.individuals.IndividualModel.identifiers.0.identifierId}}"
                 },
                 {
                   "key": "AGE",
-                  "value":
-                      "{{fn:formatDate(contextData.0.individuals.IndividualModel.dateOfBirth, 'age')}}"
+                  "value": "{{fn:formatDate(contextData.0.individuals.IndividualModel.dateOfBirth, 'age')}}"
                 },
                 {
                   "key": "GENDER",
-                  "value":
-                      "{{contextData.0.individuals.IndividualModel.gender}}"
+                  "value": "{{contextData.0.individuals.IndividualModel.gender}}"
                 },
                 {
                   "key": "MOBILE_NUMBER",
-                  "value":
-                      "{{contextData.0.individuals.IndividualModel.mobileNumber}}"
+                  "value": "{{contextData.0.individuals.IndividualModel.mobileNumber}}"
                 },
                 {
                   "key": "DATE_OF_REGISTRATION",
-                  "value":
-                      "{{fn:formatDate(contextData.0.projectBeneficiaries.ProjectBeneficiaryModel.dateOfRegistration, 'date', dd MMM yyyy)}}"
+                  "value": "{{fn:formatDate(contextData.0.projectBeneficiaries.ProjectBeneficiaryModel.dateOfRegistration, 'date', dd MMM yyyy)}}"
                 }
               ],
               "type": "template",
@@ -229,7 +240,9 @@ final dynamic sampleSMCFlows = {
             }
           ],
           "fieldName": "detailsCard",
-          "properties": {"type": "primary"},
+          "properties": {
+            "type": "primary"
+          },
           "schemaCode": null
         },
         {
@@ -253,15 +266,12 @@ final dynamic sampleSMCFlows = {
                       "@default": "REGISTRATION_CURRENT_DOSE_STATUS_PENDING",
                       "@condition": [
                         {
-                          "when":
-                              "{{fn:isDoseCompleted(item.id, contextData.0.currentRunningCycle)}} == true",
-                          "value":
-                              "REGISTRATION_CURRENT_DOSE_STATUS_ADMINISTERED"
+                          "when": "{{fn:isDoseCompleted(item.id, contextData.0.currentRunningCycle)}} == true",
+                          "value": "REGISTRATION_CURRENT_DOSE_STATUS_ADMINISTERED"
                         },
                         {
                           "when": "{{item.id}} == {{contextData.0.nextDoseId}}",
-                          "value":
-                              "REGISTRATION_CURRENT_DOSE_STATUS_TOBE_ADMINISTERED"
+                          "value": "REGISTRATION_CURRENT_DOSE_STATUS_TOBE_ADMINISTERED"
                         }
                       ]
                     }
@@ -269,8 +279,7 @@ final dynamic sampleSMCFlows = {
                   {
                     "header": "COMPLETED_ON",
                     "isActive": true,
-                    "cellValue":
-                        "{{fn:getTaskCompletionDate(item.id, contextData.0.currentRunningCycle)}}"
+                    "cellValue": "{{fn:getTaskCompletionDate(item.id, contextData.0.currentRunningCycle)}}"
                   }
                 ]
               },
@@ -294,7 +303,9 @@ final dynamic sampleSMCFlows = {
                         "value": "REGISTRATION_PAST_CYCLE {{item.id}}",
                         "format": "textTemplate",
                         "fieldName": "cycleNumber",
-                        "properties": {"style": "headingS"}
+                        "properties": {
+                          "style": "headingS"
+                        }
                       },
                       {
                         "data": {
@@ -309,14 +320,11 @@ final dynamic sampleSMCFlows = {
                               "header": "DELIVERY_STATUS",
                               "isActive": true,
                               "cellValue": {
-                                "@default":
-                                    "REGISTRATION_PAST_DOSE_STATUS_PENDING",
+                                "@default": "REGISTRATION_PAST_DOSE_STATUS_PENDING",
                                 "@condition": [
                                   {
-                                    "when":
-                                        "{{fn:isDoseCompleted(item.id, currentItem.id)}} == true",
-                                    "value":
-                                        "REGISTRATION_PAST_DOSE_STATUS_ADMINISTERED"
+                                    "when": "{{fn:isDoseCompleted(item.id, currentItem.id)}} == true",
+                                    "value": "REGISTRATION_PAST_DOSE_STATUS_ADMINISTERED"
                                   }
                                 ]
                               }
@@ -324,8 +332,7 @@ final dynamic sampleSMCFlows = {
                             {
                               "header": "COMPLETED_ON",
                               "isActive": true,
-                              "cellValue":
-                                  "{{fn:getTaskCompletionDate(item.id, currentItem.id)}}"
+                              "cellValue": "{{fn:getTaskCompletionDate(item.id, currentItem.id)}}"
                             }
                           ]
                         },
@@ -335,13 +342,17 @@ final dynamic sampleSMCFlows = {
                       }
                     ],
                     "fieldName": "card2",
-                    "properties": {"type": "secondary"}
+                    "properties": {
+                      "type": "secondary"
+                    }
                   },
                   "format": "listView",
                   "visible": "{{fn:length(contextData.0.pastCycles)}} > 0",
                   "fieldName": "pastCyclesList",
                   "dataSource": "pastCycles",
-                  "properties": {"spacing": "spacer4"}
+                  "properties": {
+                    "spacing": "spacer4"
+                  }
                 }
               ],
               "fieldName": "expandable",
@@ -351,7 +362,9 @@ final dynamic sampleSMCFlows = {
             }
           ],
           "fieldName": "card",
-          "properties": {"type": "primary"},
+          "properties": {
+            "type": "primary"
+          },
           "schemaCode": null
         }
       ],
@@ -362,8 +375,7 @@ final dynamic sampleSMCFlows = {
           "type": "template",
           "label": "RECORD_CYCLE_DOSE",
           "format": "actionPopup",
-          "visible":
-              "{{fn:hasStockForDelivery(contextData.0.eligibleProductVariants)}} == false",
+          "visible": "{{fn:hasStockForDelivery(contextData.0.eligibleProductVariants)}} == false",
           "fieldName": "insufficientStockPopUp",
           "properties": {
             "icon": "Warning",
@@ -379,7 +391,10 @@ final dynamic sampleSMCFlows = {
                   "fieldName": "insufficientStockMessageText",
                   "properties": {
                     "replaceAll": [
-                      {"searchValue": "::", "replaceValue": "\n"}
+                      {
+                        "searchValue": "::",
+                        "replaceValue": "\n"
+                      }
                     ],
                     "separatedBy": "::"
                   }
@@ -396,7 +411,9 @@ final dynamic sampleSMCFlows = {
                   "onAction": [
                     {
                       "actionType": "CLOSE_POPUP",
-                      "properties": {"parentScreenKey": "beneficiaryDetails"}
+                      "properties": {
+                        "parentScreenKey": "beneficiaryDetails"
+                      }
                     }
                   ],
                   "fieldName": "closePopUp",
@@ -420,10 +437,8 @@ final dynamic sampleSMCFlows = {
           "type": "template",
           "label": "RECORD_CYCLE_DOSE",
           "format": "button",
-          "visible":
-              "{{fn:canRecordDelivery(contextData.0.nextCycleId)}}==true && {{fn:hasStockForDelivery(contextData.0.eligibleProductVariants)}} == true",
-          "disabled":
-              "{{fn:hasStockForDelivery(contextData.0.eligibleProductVariants)}} == false",
+          "visible": "{{fn:canRecordDelivery(contextData.0.nextCycleId)}}==true && {{fn:hasStockForDelivery(contextData.0.eligibleProductVariants)}} == true",
+          "disabled": "{{fn:hasStockForDelivery(contextData.0.eligibleProductVariants)}} == false",
           "onAction": [
             {
               "actionType": "NAVIGATION",
@@ -431,8 +446,7 @@ final dynamic sampleSMCFlows = {
                 "data": [
                   {
                     "key": "ProjectBeneficiaryClientReferenceId",
-                    "value":
-                        "{{contextData.0.projectBeneficiaries.0.clientReferenceId}}"
+                    "value": "{{contextData.0.projectBeneficiaries.0.clientReferenceId}}"
                   },
                   {
                     "key": "HouseholdClientReferenceId",
@@ -444,17 +458,28 @@ final dynamic sampleSMCFlows = {
                   },
                   {
                     "key": "individualClientReferenceId",
-                    "value":
-                        "{{navigation.selectedIndividualClientReferenceId}}"
+                    "value": "{{navigation.selectedIndividualClientReferenceId}}"
                   },
                   {
                     "key": "beneficiaryId",
                     "value": "{{navigation.selectedIndividualIdentifierId}}"
                   },
-                  {"key": "childName", "value": "{{navigation.childName}}"},
-                  {"key": "ageInMonths", "value": "{{navigation.ageInMonths}}"},
-                  {"key": "gender", "value": "{{navigation.gender}}"},
-                  {"key": "headName", "value": "{{navigation.headName}}"},
+                  {
+                    "key": "childName",
+                    "value": "{{navigation.childName}}"
+                  },
+                  {
+                    "key": "ageInMonths",
+                    "value": "{{navigation.ageInMonths}}"
+                  },
+                  {
+                    "key": "gender",
+                    "value": "{{navigation.gender}}"
+                  },
+                  {
+                    "key": "headName",
+                    "value": "{{navigation.headName}}"
+                  },
                   {
                     "key": "headMobileNumber",
                     "value": "{{navigation.headMobileNumber}}"
@@ -463,11 +488,13 @@ final dynamic sampleSMCFlows = {
                     "key": "cycleIndex",
                     "value": "{{contextData.0.nextCycleId}}"
                   },
-                  {"key": "doseIndex", "value": "{{contextData.0.nextDoseId}}"},
+                  {
+                    "key": "doseIndex",
+                    "value": "{{contextData.0.nextDoseId}}"
+                  },
                   {
                     "key": "deliveryStrategy",
-                    "value":
-                        "{{contextData.0.currentDelivery.0.deliveryStrategy}}"
+                    "value": "{{contextData.0.currentDelivery.0.deliveryStrategy}}"
                   },
                   {
                     "key": "totalDosesInCycle",
@@ -500,7 +527,10 @@ final dynamic sampleSMCFlows = {
           "onAction": [
             {
               "actionType": "BACK_NAVIGATION",
-              "properties": {"name": "householdOverview", "type": "TEMPLATE"}
+              "properties": {
+                "name": "householdOverview",
+                "type": "TEMPLATE"
+              }
             }
           ]
         }
@@ -570,12 +600,18 @@ final dynamic sampleSMCFlows = {
               "else": 1,
               "then": {
                 "if": {
-                  "left": {"value": "{{dose}}", "operation": "increment"},
+                  "left": {
+                    "value": "{{dose}}",
+                    "operation": "increment"
+                  },
                   "right": "{{deliveryLength}}",
                   "operator": "lte"
                 },
                 "else": 1,
-                "then": {"value": "{{dose}}", "operation": "increment"}
+                "then": {
+                  "value": "{{dose}}",
+                  "operation": "increment"
+                }
               }
             }
           },
@@ -591,11 +627,17 @@ final dynamic sampleSMCFlows = {
               "else": "{{currentRunningCycle}}",
               "then": {
                 "if": {
-                  "left": {"value": "{{dose}}", "operation": "increment"},
+                  "left": {
+                    "value": "{{dose}}",
+                    "operation": "increment"
+                  },
                   "right": "{{deliveryLength}}",
                   "operator": "lte"
                 },
-                "else": {"value": "{{cycle}}", "operation": "increment"},
+                "else": {
+                  "value": "{{cycle}}",
+                  "operation": "increment"
+                },
                 "then": "{{cycle}}"
               }
             }
@@ -614,8 +656,7 @@ final dynamic sampleSMCFlows = {
             }
           },
           "deliveryLength": {
-            "from":
-                "{{singleton.selectedProject.additionalDetails.projectType.cycles}}",
+            "from": "{{singleton.selectedProject.additionalDetails.projectType.cycles}}",
             "order": 3,
             "where": {
               "left": "{{id}}",
@@ -636,12 +677,19 @@ final dynamic sampleSMCFlows = {
             }
           },
           "currentRunningCycle": {
-            "from":
-                "{{singleton.selectedProject.additionalDetails.projectType.cycles}}",
+            "from": "{{singleton.selectedProject.additionalDetails.projectType.cycles}}",
             "order": 1,
             "where": [
-              {"left": "{{startDate}}", "right": "{{now}}", "operator": "lt"},
-              {"left": "{{endDate}}", "right": "{{now}}", "operator": "gt"}
+              {
+                "left": "{{startDate}}",
+                "right": "{{now}}",
+                "operator": "lt"
+              },
+              {
+                "left": "{{endDate}}",
+                "right": "{{now}}",
+                "operator": "gt"
+              }
             ],
             "select": "{{id}}",
             "default": -1,
@@ -710,8 +758,7 @@ final dynamic sampleSMCFlows = {
         "wrapperName": "DeliveryWrapper",
         "computedList": {
           "pastCycles": {
-            "from":
-                "{{singleton.selectedProject.additionalDetails.projectType.cycles}}",
+            "from": "{{singleton.selectedProject.additionalDetails.projectType.cycles}}",
             "order": 6,
             "where": {
               "left": "{{item.id}}",
@@ -729,8 +776,7 @@ final dynamic sampleSMCFlows = {
             }
           },
           "targetCycle": {
-            "from":
-                "{{singleton.selectedProject.additionalDetails.projectType.cycles}}",
+            "from": "{{singleton.selectedProject.additionalDetails.projectType.cycles}}",
             "order": 1,
             "where": {
               "left": "{{id}}",
@@ -753,7 +799,9 @@ final dynamic sampleSMCFlows = {
           },
           "futureDeliveries": {
             "from": "{{targetCycle.0.deliveries}}",
-            "skip": {"from": "{{effectiveDose}}"},
+            "skip": {
+              "from": "{{effectiveDose}}"
+            },
             "order": 3,
             "where": {
               "left": "{{item.deliveryStrategy}}",
@@ -767,10 +815,24 @@ final dynamic sampleSMCFlows = {
             "fallback": [],
             "takeLast": false,
             "evaluateCondition": {
-              "context": ["{{individuals.0}}", "{{household.0}}"],
+              "context": [
+                "{{individuals.0}}",
+                "{{household.0}}"
+              ],
               "condition": "{{item.condition}}",
               "transformations": {
-                "age": {"type": "ageInMonths", "source": "dateOfBirth"}
+                "age": {
+                  "type": "ageInMonths",
+                  "source": "dateOfBirth"
+                },
+                "height": {
+                  "type": "int",
+                  "source": "height"
+                },
+                "weight": {
+                  "type": "int",
+                  "source": "weight"
+                }
               }
             }
           }
@@ -798,7 +860,9 @@ final dynamic sampleSMCFlows = {
           "heading": "REFERRAL_SUCCESSFUL_PANEL_CARD_HEADING",
           "fieldName": "successCard",
           "mandatory": true,
-          "properties": {"type": "success"},
+          "properties": {
+            "type": "success"
+          },
           "description": "REGISTRATION_ID_DESCRIPTION",
           "primaryAction": {
             "type": "template",
@@ -812,8 +876,7 @@ final dynamic sampleSMCFlows = {
                   "data": [
                     {
                       "key": "selectedIndividualClientReferenceId",
-                      "value":
-                          "{{navigation.selectedIndividualClientReferenceId}}"
+                      "value": "{{navigation.selectedIndividualClientReferenceId}}"
                     },
                     {
                       "key": "selectedIndividualIdentifierId",
@@ -831,9 +894,13 @@ final dynamic sampleSMCFlows = {
             ],
             "fieldName": "viewHouseholdButton",
             "mandatory": true,
-            "properties": {"type": "primary"}
+            "properties": {
+              "type": "primary"
+            }
           },
-          "descriptionArgs": ["{{navigation.selectedIndividualIdentifierId}}"],
+          "descriptionArgs": [
+            "{{navigation.selectedIndividualIdentifierId}}"
+          ],
           "secondaryAction": {
             "type": "template",
             "label": "GO_BACK",
@@ -842,12 +909,17 @@ final dynamic sampleSMCFlows = {
             "onAction": [
               {
                 "actionType": "NAVIGATION",
-                "properties": {"name": "searchBeneficiary", "type": "TEMPLATE"}
+                "properties": {
+                  "name": "searchBeneficiary",
+                  "type": "TEMPLATE"
+                }
               }
             ],
             "fieldName": "goBack",
             "mandatory": true,
-            "properties": {"type": "secondary"}
+            "properties": {
+              "type": "secondary"
+            }
           },
           "primaryActionLabel": "REFERRAL_VIEW_HOUSEHOLD_DETAILS",
           "secondaryActionLabel": "GO_BACK"
@@ -905,7 +977,9 @@ final dynamic sampleSMCFlows = {
                       "actionType": "REVERSE_TRANSFORM",
                       "properties": {
                         "configName": "beneficiaryRegistration",
-                        "entityTypes": ["HouseholdModel"]
+                        "entityTypes": [
+                          "HouseholdModel"
+                        ]
                       }
                     },
                     {
@@ -916,7 +990,10 @@ final dynamic sampleSMCFlows = {
                             "key": "HouseholdClientReferenceId",
                             "value": "{{ context.household.clientReferenceId }}"
                           },
-                          {"key": "isEdit", "value": "true"}
+                          {
+                            "key": "isEdit",
+                            "value": "true"
+                          }
                         ],
                         "name": "HOUSEHOLD",
                         "type": "FORM"
@@ -935,26 +1012,25 @@ final dynamic sampleSMCFlows = {
                 }
               ],
               "fieldName": "row",
-              "properties": {"mainAxisAlignment": "end"}
+              "properties": {
+                "mainAxisAlignment": "end"
+              }
             },
             {
               "data": [
                 {
                   "key": "HOUSEHOLD_HEAD_NAME",
-                  "value":
-                      "{{contextData.0.headIndividual.IndividualModel.name.givenName}}",
+                  "value": "{{contextData.0.headIndividual.IndividualModel.name.givenName}}",
                   "isActive": true
                 },
                 {
                   "key": "HOUSEHOLD_LOCALITY",
-                  "value":
-                      "{{contextData.0.household.HouseholdModel.address.locality.code}}",
+                  "value": "{{contextData.0.household.HouseholdModel.address.locality.code}}",
                   "isActive": true
                 },
                 {
                   "key": "MEMBER_COUNT",
-                  "value":
-                      "{{contextData.0.household.HouseholdModel.memberCount}}",
+                  "value": "{{contextData.0.household.HouseholdModel.memberCount}}",
                   "isActive": true
                 }
               ],
@@ -982,8 +1058,7 @@ final dynamic sampleSMCFlows = {
                         "type": "template",
                         "label": "REGISTRATION_EDIT_INDIVIDUAL_BUTTON_LABEL",
                         "format": "button",
-                        "disabled":
-                            "{{fn:disableEdit(item.task, item.hFReferral)}}==true",
+                        "disabled": "{{fn:disableEdit(item.task, item.hFReferral)}}==true",
                         "onAction": [
                           {
                             "actionType": "REVERSE_TRANSFORM",
@@ -1011,10 +1086,12 @@ final dynamic sampleSMCFlows = {
                               "data": [
                                 {
                                   "key": "HouseholdClientReferenceId",
-                                  "value":
-                                      "{{item.member.0.householdClientReferenceId}}"
+                                  "value": "{{item.member.0.householdClientReferenceId}}"
                                 },
-                                {"key": "isEdit", "value": "true"}
+                                {
+                                  "key": "isEdit",
+                                  "value": "true"
+                                }
                               ],
                               "name": "ADD_MEMBER",
                               "type": "FORM"
@@ -1041,73 +1118,71 @@ final dynamic sampleSMCFlows = {
                   },
                   {
                     "type": "template",
-                    "value":
-                        "{{item.individual.0.gender }} | {{fn:formatDate(item.individual.0.dateOfBirth, 'age')}}",
+                    "value": "{{item.individual.0.gender }} | {{fn:formatDate(item.individual.0.dateOfBirth, 'age')}}",
                     "format": "textTemplate",
                     "fieldName": "genderAge",
-                    "properties": {"bottomGap": 16}
-                  },
-                  {
-                    "type": "template",
-                    "label":
-                        "{{fn:getUniqueBeneficiaryId(item.individual.0.identifiers.0)}}",
-                    "format": "tag",
-                    "visible":
-                        "{{fn:getUniqueBeneficiaryId(item.individual.0.identifiers.0)}} != ''",
-                    "fieldName": "uniqueBeneficiaryIdTag",
-                    "properties": {"tagType": "info", "bottomGap": 16}
+                    "properties": {
+                      "bottomGap": 16
+                    }
                   },
                   {
                     "type": "template",
                     "label": "{{fn:getInEligibleStatus(item.task)}}",
                     "format": "tag",
-                    "visible":
-                        "{{fn:checkEligibilityForAgeAndSideEffect(item.individual.0.dateOfBirth, item.task, contextData.0.currentRunningCycle)}}==false && {{fn:hasReferralForCurrentCycle(item.hFReferral)}}==false",
+                    "visible": "{{fn:checkEligibilityForAgeAndSideEffect(item.individual.0.dateOfBirth, item.task, contextData.0.currentRunningCycle)}}==false && {{fn:hasReferralForCurrentCycle(item.hFReferral)}}==false",
                     "fieldName": "notEligible",
-                    "properties": {"tagType": "error"}
+                    "properties": {
+                      "tagType": "error"
+                    }
                   },
                   {
                     "type": "template",
                     "label": "BENEFICIARY_REFERRED",
                     "format": "tag",
-                    "visible":
-                        "{{fn:hasReferralForCurrentCycle(item.hFReferral)}}==true",
+                    "visible": "{{fn:hasReferralForCurrentCycle(item.hFReferral)}}==true",
                     "fieldName": "beneficiaryReferred",
-                    "properties": {"tagType": "error"}
+                    "properties": {
+                      "tagType": "error"
+                    }
                   },
                   {
                     "type": "template",
                     "label": "ADMINISTERED_SUCCESS",
                     "format": "tag",
-                    "visible":
-                        "{{fn:isDelivered(item.task.last.status)}}==true && {{fn:hasRedoseForCurrentCycle(item.task)}}==false && {{fn:checkEligibilityForAgeAndSideEffect(item.individual.0.dateOfBirth, item.task, contextData.0.currentRunningCycle)}}==true && {{fn:hasReferralForCurrentCycle(item.hFReferral)}}==false",
+                    "visible": "{{fn:isDelivered(item.task.last.status)}}==true && {{fn:hasRedoseForCurrentCycle(item.task)}}==false && {{fn:checkEligibilityForAgeAndSideEffect(item.individual.0.dateOfBirth, item.task, contextData.0.currentRunningCycle)}}==true && {{fn:hasReferralForCurrentCycle(item.hFReferral)}}==false",
                     "fieldName": "administrationSuccess",
-                    "properties": {"tagType": "success", "bottomGap": 16}
+                    "properties": {
+                      "tagType": "success",
+                      "bottomGap": 16
+                    }
                   },
                   {
                     "type": "template",
                     "label": "REDOSE_COMPLETED",
                     "format": "tag",
-                    "visible":
-                        "{{fn:hasRedoseForCurrentCycle(item.task)}}==true && {{fn:checkEligibilityForAgeAndSideEffect(item.individual.0.dateOfBirth, item.task, contextData.0.currentRunningCycle)}}==true && {{fn:hasReferralForCurrentCycle(item.hFReferral)}}==false",
+                    "visible": "{{fn:hasRedoseForCurrentCycle(item.task)}}==true && {{fn:checkEligibilityForAgeAndSideEffect(item.individual.0.dateOfBirth, item.task, contextData.0.currentRunningCycle)}}==true && {{fn:hasReferralForCurrentCycle(item.hFReferral)}}==false",
                     "fieldName": "redoseCompleted",
-                    "properties": {"tagType": "success", "bottomGap": 16}
+                    "properties": {
+                      "tagType": "success",
+                      "bottomGap": 16
+                    }
                   },
                   {
                     "type": "template",
                     "label": "NOT_VISITED",
                     "format": "tag",
-                    "visible":
-                        "{{fn:checkEligibilityForAgeAndSideEffect(item.individual.0.dateOfBirth, item.task, contextData.0.currentRunningCycle)}}==true && {{fn:isDelivered(item.task.last.status)}}==false && {{fn:hasReferralForCurrentCycle(item.hFReferral)}}==false && {{fn:hasUnableToDeliverForCurrentCycle(item.task)}}==false && {{fn:hasRedoseForCurrentCycle(item.task)}}==false",
+                    "visible": "{{fn:checkEligibilityForAgeAndSideEffect(item.individual.0.dateOfBirth, item.task, contextData.0.currentRunningCycle)}}==true && {{fn:isDelivered(item.task.last.status)}}==false && {{fn:hasReferralForCurrentCycle(item.hFReferral)}}==false && {{fn:hasUnableToDeliverForCurrentCycle(item.task)}}==false && {{fn:hasRedoseForCurrentCycle(item.task)}}==false",
                     "fieldName": "notVisited",
-                    "properties": {"tagType": "info", "bottomGap": 16}
+                    "properties": {
+                      "tagType": "info",
+                      "bottomGap": 16
+                    }
                   },
                   {
                     "type": "template",
                     "label": "DELIVERY",
                     "format": "button",
-                    "visible":
-                        "{{fn:checkEligibilityForAgeAndSideEffect(item.individual.0.dateOfBirth, item.task,contextData.0.currentRunningCycle)}} == true  && {{fn:checkAllDoseDelivered(item.task)}} == false && {{fn:hasReferralForCurrentCycle(item.hFReferral)}}==false && {{fn:hasRedoseForCurrentCycle(item.task)}}==false",
+                    "visible": "{{fn:checkEligibilityForAgeAndSideEffect(item.individual.0.dateOfBirth, item.task,contextData.0.currentRunningCycle)}} == true  && {{fn:checkAllDoseDelivered(item.task)}} == false && {{fn:hasReferralForCurrentCycle(item.hFReferral)}}==false && {{fn:hasRedoseForCurrentCycle(item.task)}}==false",
                     "onAction": [
                       {
                         "actionType": "NAVIGATION",
@@ -1119,18 +1194,15 @@ final dynamic sampleSMCFlows = {
                             },
                             {
                               "key": "selectedIndividualIdentifierId",
-                              "value":
-                                  "{{item.individual.0.identifiers.0.identifierId}}"
+                              "value": "{{item.individual.0.identifiers.0.identifierId}}"
                             },
                             {
                               "key": "HouseholdClientReferenceId",
-                              "value":
-                                  "{{item.member.0.householdClientReferenceId}}"
+                              "value": "{{item.member.0.householdClientReferenceId}}"
                             },
                             {
                               "key": "ProjectBeneficiaryClientReferenceId",
-                              "value":
-                                  "{{item.projectBeneficiary.0.clientReferenceId}}"
+                              "value": "{{item.projectBeneficiary.0.clientReferenceId}}"
                             },
                             {
                               "key": "selectedIndividualName",
@@ -1142,8 +1214,7 @@ final dynamic sampleSMCFlows = {
                             },
                             {
                               "key": "selectedIndividualAgeInMonths",
-                              "value":
-                                  "{{fn:formatDate(item.individual.0.dateOfBirth, 'ageInMonths')}}"
+                              "value": "{{fn:formatDate(item.individual.0.dateOfBirth, 'ageInMonths')}}"
                             },
                             {
                               "key": "cycleIndex",
@@ -1169,8 +1240,7 @@ final dynamic sampleSMCFlows = {
                     "type": "template",
                     "label": "HOUSEHOLD_OVERVIEW_UNABLE_TO_DELIVER_LABEL",
                     "format": "button",
-                    "visible":
-                        "{{fn:checkEligibilityForAgeAndSideEffect(item.individual.0.dateOfBirth, item.task, contextData.0.currentRunningCycle)}} == true && {{fn:checkAllDoseDelivered(item.task)}} == false && {{fn:hasReferralForCurrentCycle(item.hFReferral)}}==false",
+                    "visible": "{{fn:checkEligibilityForAgeAndSideEffect(item.individual.0.dateOfBirth, item.task, contextData.0.currentRunningCycle)}} == true && {{fn:checkAllDoseDelivered(item.task)}} == false && {{fn:hasReferralForCurrentCycle(item.hFReferral)}}==false",
                     "onAction": [
                       {
                         "actionType": "NAVIGATION",
@@ -1182,13 +1252,11 @@ final dynamic sampleSMCFlows = {
                             },
                             {
                               "key": "HouseholdClientReferenceId",
-                              "value":
-                                  "{{item.member.0.householdClientReferenceId}}"
+                              "value": "{{item.member.0.householdClientReferenceId}}"
                             },
                             {
                               "key": "ProjectBeneficiaryClientReferenceId",
-                              "value":
-                                  "{{item.projectBeneficiary.0.clientReferenceId}}"
+                              "value": "{{item.projectBeneficiary.0.clientReferenceId}}"
                             },
                             {
                               "key": "cycleIndex",
@@ -1215,8 +1283,7 @@ final dynamic sampleSMCFlows = {
                     "type": "template",
                     "label": "REGISTRATION_VIEW_DETAILS",
                     "format": "button",
-                    "visible":
-                        "{{fn:checkEligibilityForAgeAndSideEffect(item.individual.0.dateOfBirth, item.task,contextData.0.currentRunningCycle)}} == true &&  {{fn:checkAllDoseDelivered(item.task)}} == true && {{fn:hasReferralForCurrentCycle(item.hFReferral)}}==false",
+                    "visible": "{{fn:checkEligibilityForAgeAndSideEffect(item.individual.0.dateOfBirth, item.task,contextData.0.currentRunningCycle)}} == true &&  {{fn:checkAllDoseDelivered(item.task)}} == true && {{fn:hasReferralForCurrentCycle(item.hFReferral)}}==false",
                     "onAction": [
                       {
                         "actionType": "NAVIGATION",
@@ -1228,18 +1295,15 @@ final dynamic sampleSMCFlows = {
                             },
                             {
                               "key": "selectedIndividualIdentifierId",
-                              "value":
-                                  "{{item.individual.0.identifiers.0.identifierId}}"
+                              "value": "{{item.individual.0.identifiers.0.identifierId}}"
                             },
                             {
                               "key": "HouseholdClientReferenceId",
-                              "value":
-                                  "{{item.member.0.householdClientReferenceId}}"
+                              "value": "{{item.member.0.householdClientReferenceId}}"
                             },
                             {
                               "key": "ProjectBeneficiaryClientReferenceId",
-                              "value":
-                                  "{{item.projectBeneficiary.0.clientReferenceId}}"
+                              "value": "{{item.projectBeneficiary.0.clientReferenceId}}"
                             },
                             {
                               "key": "selectedIndividualName",
@@ -1251,8 +1315,7 @@ final dynamic sampleSMCFlows = {
                             },
                             {
                               "key": "selectedIndividualAgeInMonths",
-                              "value":
-                                  "{{fn:formatDate(item.individual.0.dateOfBirth, 'ageInMonths')}}"
+                              "value": "{{fn:formatDate(item.individual.0.dateOfBirth, 'ageInMonths')}}"
                             },
                             {
                               "key": "cycleIndex",
@@ -1278,8 +1341,7 @@ final dynamic sampleSMCFlows = {
                     "type": "template",
                     "label": "REDOSE_ADMINISTRATION",
                     "format": "button",
-                    "visible":
-                        "{{fn:checkEligibilityForAgeAndSideEffect(item.individual.0.dateOfBirth, item.task,contextData.0.currentRunningCycle)}} == true && {{fn:checkAllDoseDelivered(item.task)}} == true && {{fn:hasReferralForCurrentCycle(item.hFReferral)}}==false && {{fn:hasRedoseForCurrentCycle(item.task)}}==false",
+                    "visible": "{{fn:checkEligibilityForAgeAndSideEffect(item.individual.0.dateOfBirth, item.task,contextData.0.currentRunningCycle)}} == true && {{fn:checkAllDoseDelivered(item.task)}} == true && {{fn:hasReferralForCurrentCycle(item.hFReferral)}}==false && {{fn:hasRedoseForCurrentCycle(item.task)}}==false",
                     "disabled": "{{fn:isRedoseWindowExpired(item.task)}}==true",
                     "onAction": [
                       {
@@ -1292,18 +1354,15 @@ final dynamic sampleSMCFlows = {
                             },
                             {
                               "key": "selectedIndividualIdentifierId",
-                              "value":
-                                  "{{item.individual.0.identifiers.0.identifierId}}"
+                              "value": "{{item.individual.0.identifiers.0.identifierId}}"
                             },
                             {
                               "key": "HouseholdClientReferenceId",
-                              "value":
-                                  "{{item.member.0.householdClientReferenceId}}"
+                              "value": "{{item.member.0.householdClientReferenceId}}"
                             },
                             {
                               "key": "ProjectBeneficiaryClientReferenceId",
-                              "value":
-                                  "{{item.projectBeneficiary.0.clientReferenceId}}"
+                              "value": "{{item.projectBeneficiary.0.clientReferenceId}}"
                             },
                             {
                               "key": "selectedIndividualName",
@@ -1315,8 +1374,7 @@ final dynamic sampleSMCFlows = {
                             },
                             {
                               "key": "selectedIndividualAgeInMonths",
-                              "value":
-                                  "{{fn:formatDate(item.individual.0.dateOfBirth, 'ageInMonths')}}"
+                              "value": "{{fn:formatDate(item.individual.0.dateOfBirth, 'ageInMonths')}}"
                             },
                             {
                               "key": "cycleIndex",
@@ -1354,14 +1412,15 @@ final dynamic sampleSMCFlows = {
               "hidden": false,
               "fieldName": "listViewMembers",
               "dataSource": "members",
-              "properties": {"spacing": "spacer4"}
+              "properties": {
+                "spacing": "spacer4"
+              }
             },
             {
               "type": "template",
               "label": "ADD_MEMBER",
               "format": "actionPopup",
-              "visible":
-                  "{{fn:hasMinimumBeneficiaryId(singleton.beneficiaryIdMinCount, uniqueIdPoolCount)}}==false",
+              "visible": "{{fn:hasMinimumBeneficiaryId(singleton.beneficiaryIdMinCount, uniqueIdPoolCount)}}==false",
               "fieldName": "beneficiaryIdMinCheck",
               "properties": {
                 "size": "medium",
@@ -1370,20 +1429,19 @@ final dynamic sampleSMCFlows = {
                 "popupConfig": {
                   "body": [],
                   "type": "alert",
-                  "title":
-                      "REGISTRATION_SEARCH_BENEFICIARY_MIN_BENEFICIARY_ID_LEFT_TITLE",
-                  "description":
-                      "REGISTRATION_SEARCH_BENEFICIARY_MIN_BENEFICIARY_ID_LEFT_DESCRIPTION",
+                  "title": "REGISTRATION_SEARCH_BENEFICIARY_MIN_BENEFICIARY_ID_LEFT_TITLE",
+                  "description": "REGISTRATION_SEARCH_BENEFICIARY_MIN_BENEFICIARY_ID_LEFT_DESCRIPTION",
                   "footerActions": [
                     {
                       "type": "template",
-                      "label":
-                          "REGISTRATION_SEARCH_BENEFICIARY_SKIP_CONTINUE_LABEL",
+                      "label": "REGISTRATION_SEARCH_BENEFICIARY_SKIP_CONTINUE_LABEL",
                       "format": "button",
                       "onAction": [
                         {
                           "actionType": "CLOSE_POPUP",
-                          "properties": {"parentScreenKey": "searchBeneficiary"}
+                          "properties": {
+                            "parentScreenKey": "searchBeneficiary"
+                          }
                         },
                         {
                           "actionType": "NAVIGATION",
@@ -1391,8 +1449,7 @@ final dynamic sampleSMCFlows = {
                             "data": [
                               {
                                 "key": "HouseholdClientReferenceId",
-                                "value":
-                                    "{{contextData.0.household.HouseholdModel.clientReferenceId}}"
+                                "value": "{{contextData.0.household.HouseholdModel.clientReferenceId}}"
                               },
                               {
                                 "key": "UNIQUE_BENEFICIARY_ID",
@@ -1418,7 +1475,9 @@ final dynamic sampleSMCFlows = {
                       "onAction": [
                         {
                           "actionType": "CLOSE_POPUP",
-                          "properties": {"parentScreenKey": "searchBeneficiary"}
+                          "properties": {
+                            "parentScreenKey": "searchBeneficiary"
+                          }
                         },
                         {
                           "actionType": "NAVIGATE_TO_BENEFICIARY_ID_DOWN_SYNC",
@@ -1445,8 +1504,7 @@ final dynamic sampleSMCFlows = {
               "type": "template",
               "label": "ADD_MEMBER",
               "format": "button",
-              "visible":
-                  "{{fn:hasMinimumBeneficiaryId(singleton.beneficiaryIdMinCount, uniqueIdPoolCount)}}==true",
+              "visible": "{{fn:hasMinimumBeneficiaryId(singleton.beneficiaryIdMinCount, uniqueIdPoolCount)}}==true",
               "onAction": [
                 {
                   "actionType": "NAVIGATION",
@@ -1454,8 +1512,7 @@ final dynamic sampleSMCFlows = {
                     "data": [
                       {
                         "key": "HouseholdClientReferenceId",
-                        "value":
-                            "{{contextData.0.household.HouseholdModel.clientReferenceId}}"
+                        "value": "{{contextData.0.household.HouseholdModel.clientReferenceId}}"
                       },
                       {
                         "key": "UNIQUE_BENEFICIARY_ID",
@@ -1478,7 +1535,10 @@ final dynamic sampleSMCFlows = {
             }
           ],
           "fieldName": "card",
-          "properties": {"type": "primary", "cardType": "primary"},
+          "properties": {
+            "type": "primary",
+            "cardType": "primary"
+          },
           "schemaCode": null
         }
       ],
@@ -1492,7 +1552,10 @@ final dynamic sampleSMCFlows = {
           "onAction": [
             {
               "actionType": "NAVIGATION",
-              "properties": {"name": "searchBeneficiary", "type": "TEMPLATE"}
+              "properties": {
+                "name": "searchBeneficiary",
+                "type": "TEMPLATE"
+              }
             }
           ]
         }
@@ -1503,7 +1566,9 @@ final dynamic sampleSMCFlows = {
       "screenType": "TEMPLATE",
       "description": "REGISTRATION_HOUSEHOLD_OVERVIEW_DESC",
       "initActions": [
-        {"actionType": "LOAD_UNIQUE_ID_POOL"},
+        {
+          "actionType": "LOAD_UNIQUE_ID_POOL"
+        },
         {
           "actionType": "SEARCH_EVENT",
           "properties": {
@@ -1523,12 +1588,19 @@ final dynamic sampleSMCFlows = {
         "filters": [],
         "computed": {
           "currentRunningCycle": {
-            "from":
-                "{{singleton.selectedProject.additionalDetails.projectType.cycles}}",
+            "from": "{{singleton.selectedProject.additionalDetails.projectType.cycles}}",
             "order": 1,
             "where": [
-              {"left": "{{startDate}}", "right": "{{now}}", "operator": "lt"},
-              {"left": "{{endDate}}", "right": "{{now}}", "operator": "gt"}
+              {
+                "left": "{{startDate}}",
+                "right": "{{now}}",
+                "operator": "lt"
+              },
+              {
+                "left": "{{endDate}}",
+                "right": "{{now}}",
+                "operator": "gt"
+              }
             ],
             "select": "{{id}}",
             "default": -1,
@@ -1552,7 +1624,10 @@ final dynamic sampleSMCFlows = {
             },
             "entity": "HouseholdMemberModel",
             "filters": [
-              {"field": "isHeadOfHousehold", "equals": true}
+              {
+                "field": "isHeadOfHousehold",
+                "equals": true
+              }
             ]
           },
           {
@@ -1667,18 +1742,30 @@ final dynamic sampleSMCFlows = {
           "heading": "UNABLETODELIVERY_FLOW_SCREEN_HEADING",
           "summary": false,
           "version": 1,
-          "navigateTo": {"name": "household-overview", "type": "template"},
+          "navigateTo": {
+            "name": "household-overview",
+            "type": "template"
+          },
           "properties": [
             {
               "type": "string",
               "enums": [
-                {"code": "BENEFICIARY_DIED", "name": "BENEFICIARY_DIED"},
+                {
+                  "code": "BENEFICIARY_DIED",
+                  "name": "BENEFICIARY_DIED"
+                },
                 {
                   "code": "BENEFICIARY_MIGRATED",
                   "name": "BENEFICIARY_MIGRATED"
                 },
-                {"code": "BENEFICIARY_ABSENT", "name": "BENEFICIARY_ABSENT"},
-                {"code": "BENEFICIARY_REFUSED", "name": "BENEFICIARY_REFUSED"}
+                {
+                  "code": "BENEFICIARY_ABSENT",
+                  "name": "BENEFICIARY_ABSENT"
+                },
+                {
+                  "code": "BENEFICIARY_REFUSED",
+                  "name": "BENEFICIARY_REFUSED"
+                }
               ],
               "label": "UNABLETODELIVERY_FLOW_reason_LABEL",
               "order": 1,
@@ -1700,8 +1787,7 @@ final dynamic sampleSMCFlows = {
                 {
                   "type": "required",
                   "value": true,
-                  "message":
-                      "UNABLETODELIVERY_FLOW_reason_REQUIRED_ERROR_MESSAGE"
+                  "message": "UNABLETODELIVERY_FLOW_reason_REQUIRED_ERROR_MESSAGE"
                 }
               ],
               "errorMessage": "REGISTRATION_UNABLETODELIVER_reason_ERROR"
@@ -1746,7 +1832,10 @@ final dynamic sampleSMCFlows = {
                 "value": "BENEFICIARY_ABSENT_STATUS",
                 "expression": "unableToDeliver.reason == BENEFICIARY_ABSENT"
               },
-              {"value": "BENEFICIARY_REFUSED_STATUS", "expression": "DEFAULT"}
+              {
+                "value": "BENEFICIARY_REFUSED_STATUS",
+                "expression": "DEFAULT"
+              }
             ],
             "description": "UNABLETODELIVER_FLOWT_ALERT_DESCRIPTION",
             "primaryActionLabel": "UNABLETODELIVER_FLOW_ACTION_SUBMIT",
@@ -1770,7 +1859,10 @@ final dynamic sampleSMCFlows = {
                 "key": "ProjectBeneficiaryClientReferenceId",
                 "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
               },
-              {"key": "cycleIndex", "value": "{{navigation.cycleIndex}}"}
+              {
+                "key": "cycleIndex",
+                "value": "{{navigation.cycleIndex}}"
+              }
             ],
             "onError": [
               {
@@ -1790,7 +1882,9 @@ final dynamic sampleSMCFlows = {
             "onError": [
               {
                 "actionType": "SHOW_TOAST",
-                "properties": {"message": "Failed to create household."}
+                "properties": {
+                  "message": "Failed to create household."
+                }
               }
             ]
           }
@@ -1840,7 +1934,11 @@ final dynamic sampleSMCFlows = {
               "actionType": "field.value==true ? SEARCH_EVENT : CLEAR_STATE",
               "properties": {
                 "data": [
-                  {"key": "", "value": 5, "operation": "within"},
+                  {
+                    "key": "",
+                    "value": 5,
+                    "operation": "within"
+                  },
                   {
                     "key": "localityBoundaryCode",
                     "root": "address",
@@ -1872,8 +1970,13 @@ final dynamic sampleSMCFlows = {
             {
               "actionType": "CLEAR_STATE",
               "properties": {
-                "filterKeys": ["givenName", "identifierId"],
-                "widgetKeys": ["searchBar"],
+                "filterKeys": [
+                  "givenName",
+                  "identifierId"
+                ],
+                "widgetKeys": [
+                  "searchBar"
+                ],
                 "triggerSearch": true
               }
             }
@@ -1913,7 +2016,10 @@ final dynamic sampleSMCFlows = {
           "mandatory": true,
           "debounceMs": 300,
           "validations": [
-            {"type": "minSearchChars", "value": 2}
+            {
+              "type": "minSearchChars",
+              "value": 2
+            }
           ],
           "minSearchChars": 2
         },
@@ -1947,7 +2053,10 @@ final dynamic sampleSMCFlows = {
           "fieldName": "idSearchBar",
           "mandatory": true,
           "validations": [
-            {"type": "minSearchChars", "value": 3}
+            {
+              "type": "minSearchChars",
+              "value": 3
+            }
           ],
           "minSearchChars": 3
         },
@@ -1975,7 +2084,10 @@ final dynamic sampleSMCFlows = {
                       "code": "BENEFICIARY_REFERRED",
                       "name": "REGISTRATION_BENEFICIARY_REFERRED"
                     },
-                    {"code": "INELIGIBLE", "name": "REGISTRATION_INELIGIBLE"},
+                    {
+                      "code": "INELIGIBLE",
+                      "name": "REGISTRATION_INELIGIBLE"
+                    },
                     {
                       "code": "CLOSED_HOUSEHOLD",
                       "name": "REGISTRATION_CLOSED_HOUSEHOLD"
@@ -2007,7 +2119,9 @@ final dynamic sampleSMCFlows = {
                           "projectBeneficiary",
                           "projectId"
                         ],
-                        "widgetKeys": ["selectedStatus"],
+                        "widgetKeys": [
+                          "selectedStatus"
+                        ],
                         "triggerSearch": true
                       }
                     }
@@ -2021,13 +2135,14 @@ final dynamic sampleSMCFlows = {
                 },
                 {
                   "type": "template",
-                  "label":
-                      "REGISTRATION_SEARCH_BENEFICIARY_FILTER_FILTER_LABEL",
+                  "label": "REGISTRATION_SEARCH_BENEFICIARY_FILTER_FILTER_LABEL",
                   "format": "button",
                   "onAction": [
                     {
                       "actionType": "CLOSE_POPUP",
-                      "properties": {"parentScreenKey": "searchBeneficiary"}
+                      "properties": {
+                        "parentScreenKey": "searchBeneficiary"
+                      }
                     },
                     {
                       "actionType": "CLEAR_STATE",
@@ -2064,8 +2179,7 @@ final dynamic sampleSMCFlows = {
                         }
                       ],
                       "condition": {
-                        "expression":
-                            "selectedStatus == ADMINISTRATION_SUCCESS || selectedStatus == CLOSED_HOUSEHOLD || selectedStatus == ADMINISTRATION_FAILED || selectedStatus == INELIGIBLE"
+                        "expression": "selectedStatus == ADMINISTRATION_SUCCESS || selectedStatus == CLOSED_HOUSEHOLD || selectedStatus == ADMINISTRATION_FAILED || selectedStatus == INELIGIBLE"
                       }
                     },
                     {
@@ -2209,7 +2323,9 @@ final dynamic sampleSMCFlows = {
                           },
                           {
                             "actionType": "CREATE_EVENT",
-                            "properties": {"entity": "ProjectBeneficiaryModel"}
+                            "properties": {
+                              "entity": "ProjectBeneficiaryModel"
+                            }
                           },
                           {
                             "actionType": "NAVIGATION",
@@ -2217,8 +2333,7 @@ final dynamic sampleSMCFlows = {
                               "data": [
                                 {
                                   "key": "HouseholdClientReferenceId",
-                                  "value":
-                                      "{{ item.HouseholdModel.clientReferenceId }}"
+                                  "value": "{{ item.HouseholdModel.clientReferenceId }}"
                                 }
                               ],
                               "name": "householdOverview",
@@ -2227,8 +2342,7 @@ final dynamic sampleSMCFlows = {
                           }
                         ],
                         "condition": {
-                          "expression":
-                              "{{fn:length(item.projectBeneficiaries)}}<=0"
+                          "expression": "{{fn:length(item.projectBeneficiaries)}}<=0"
                         }
                       },
                       {
@@ -2239,8 +2353,7 @@ final dynamic sampleSMCFlows = {
                               "data": [
                                 {
                                   "key": "HouseholdClientReferenceId",
-                                  "value":
-                                      "{{ item.HouseholdModel.clientReferenceId }}"
+                                  "value": "{{ item.HouseholdModel.clientReferenceId }}"
                                 }
                               ],
                               "name": "householdOverview",
@@ -2249,8 +2362,7 @@ final dynamic sampleSMCFlows = {
                           }
                         ],
                         "condition": {
-                          "expression":
-                              "{{item.tasks.0.status}} != CLOSED_HOUSEHOLD"
+                          "expression": "{{item.tasks.0.status}} != CLOSED_HOUSEHOLD"
                         }
                       },
                       {
@@ -2259,10 +2371,16 @@ final dynamic sampleSMCFlows = {
                             "actionType": "REVERSE_TRANSFORM",
                             "properties": {
                               "data": [
-                                {"key": "entities", "value": "{{item}}"}
+                                {
+                                  "key": "entities",
+                                  "value": "{{item}}"
+                                }
                               ],
                               "configName": "beneficiaryRegistration",
-                              "entityTypes": ["HouseholdModel", "TaskModel"]
+                              "entityTypes": [
+                                "HouseholdModel",
+                                "TaskModel"
+                              ]
                             }
                           },
                           {
@@ -2271,11 +2389,16 @@ final dynamic sampleSMCFlows = {
                               "data": [
                                 {
                                   "key": "HouseholdClientReferenceId",
-                                  "value":
-                                      "{{ item.HouseholdModel.clientReferenceId }}"
+                                  "value": "{{ item.HouseholdModel.clientReferenceId }}"
                                 },
-                                {"key": "isEdit", "value": "true"},
-                                {"key": "isClosedHousehold", "value": "true"}
+                                {
+                                  "key": "isEdit",
+                                  "value": "true"
+                                },
+                                {
+                                  "key": "isClosedHousehold",
+                                  "value": "true"
+                                }
                               ],
                               "name": "HOUSEHOLD",
                               "type": "FORM"
@@ -2283,13 +2406,15 @@ final dynamic sampleSMCFlows = {
                           }
                         ],
                         "condition": {
-                          "expression":
-                              "{{item.tasks.0.status}} == CLOSED_HOUSEHOLD"
+                          "expression": "{{item.tasks.0.status}} == CLOSED_HOUSEHOLD"
                         }
                       }
                     ],
                     "fieldName": "openMemberCard",
-                    "properties": {"size": "medium", "type": "secondary"}
+                    "properties": {
+                      "size": "medium",
+                      "type": "secondary"
+                    }
                   }
                 ],
                 "fieldName": "detailsRow",
@@ -2320,13 +2445,6 @@ final dynamic sampleSMCFlows = {
                       "hidden": false,
                       "isActive": true,
                       "cellValue": "{{item.gender}}"
-                    },
-                    {
-                      "header": "UNIQUE_BENEFICIARY_ID",
-                      "hidden": false,
-                      "isActive": true,
-                      "cellValue":
-                          "{{fn:getUniqueBeneficiaryId(item.identifiers.0)}}"
                     }
                   ]
                 },
@@ -2340,7 +2458,9 @@ final dynamic sampleSMCFlows = {
           "format": "listView",
           "hidden": false,
           "fieldName": "listView",
-          "properties": {"spacing": "spacer4"},
+          "properties": {
+            "spacing": "spacer4"
+          },
           "schemaCode": null
         }
       ],
@@ -2352,8 +2472,7 @@ final dynamic sampleSMCFlows = {
           "type": "template",
           "label": "DOWNLOAD_BENEFICIARY_IDS",
           "format": "actionPopup",
-          "visible":
-              "{{fn:hasMinimumBeneficiaryId(singleton.beneficiaryIdMinCount, uniqueIdPoolCount)}}==false",
+          "visible": "{{fn:hasMinimumBeneficiaryId(singleton.beneficiaryIdMinCount, uniqueIdPoolCount)}}==false",
           "disabled": "{{searchBar}} == null || {{searchBar}} == ''",
           "fieldName": "beneficiaryIdMinCheck",
           "properties": {
@@ -2363,26 +2482,28 @@ final dynamic sampleSMCFlows = {
             "popupConfig": {
               "body": [],
               "type": "alert",
-              "title":
-                  "REGISTRATION_SEARCH_BENEFICIARY_MIN_BENEFICIARY_ID_LEFT_TITLE",
-              "description":
-                  "REGISTRATION_SEARCH_BENEFICIARY_MIN_BENEFICIARY_ID_LEFT_DESCRIPTION",
+              "title": "REGISTRATION_SEARCH_BENEFICIARY_MIN_BENEFICIARY_ID_LEFT_TITLE",
+              "description": "REGISTRATION_SEARCH_BENEFICIARY_MIN_BENEFICIARY_ID_LEFT_DESCRIPTION",
               "footerActions": [
                 {
                   "type": "template",
-                  "label":
-                      "REGISTRATION_SEARCH_BENEFICIARY_SKIP_CONTINUE_LABEL",
+                  "label": "REGISTRATION_SEARCH_BENEFICIARY_SKIP_CONTINUE_LABEL",
                   "format": "button",
                   "onAction": [
                     {
                       "actionType": "CLOSE_POPUP",
-                      "properties": {"parentScreenKey": "searchBeneficiary"}
+                      "properties": {
+                        "parentScreenKey": "searchBeneficiary"
+                      }
                     },
                     {
                       "actionType": "NAVIGATION",
                       "properties": {
                         "data": [
-                          {"key": "nameOfIndividual", "value": "{{searchBar}}"},
+                          {
+                            "key": "nameOfIndividual",
+                            "value": "{{searchBar}}"
+                          },
                           {
                             "key": "UNIQUE_BENEFICIARY_ID",
                             "value": "{{latestBeneficiaryId}}"
@@ -2411,7 +2532,9 @@ final dynamic sampleSMCFlows = {
                   "onAction": [
                     {
                       "actionType": "CLOSE_POPUP",
-                      "properties": {"parentScreenKey": "searchBeneficiary"}
+                      "properties": {
+                        "parentScreenKey": "searchBeneficiary"
+                      }
                     },
                     {
                       "actionType": "NAVIGATE_TO_BENEFICIARY_ID_DOWN_SYNC",
@@ -2438,15 +2561,17 @@ final dynamic sampleSMCFlows = {
           "type": "template",
           "label": "REGISTER_BENEFICIARY",
           "format": "button",
-          "visible":
-              "{{fn:hasMinimumBeneficiaryId(singleton.beneficiaryIdMinCount, uniqueIdPoolCount)}}==true",
+          "visible": "{{fn:hasMinimumBeneficiaryId(singleton.beneficiaryIdMinCount, uniqueIdPoolCount)}}==true",
           "disabled": "{{searchBar}} == null || {{searchBar}} == ''",
           "onAction": [
             {
               "actionType": "NAVIGATION",
               "properties": {
                 "data": [
-                  {"key": "nameOfIndividual", "value": "{{searchBar}}"},
+                  {
+                    "key": "nameOfIndividual",
+                    "value": "{{searchBar}}"
+                  },
                   {
                     "key": "UNIQUE_BENEFICIARY_ID",
                     "value": "{{latestBeneficiaryId}}"
@@ -2526,7 +2651,10 @@ final dynamic sampleSMCFlows = {
               "value": 1,
               "message": "SCANLIMIT_ERROR_MESSAGE"
             },
-            {"type": "isGS1", "value": false}
+            {
+              "type": "isGS1",
+              "value": false
+            }
           ],
           "scanLimit.message": "SCANLIMIT_ERROR_MESSAGE"
         }
@@ -2538,7 +2666,10 @@ final dynamic sampleSMCFlows = {
           "onAction": [
             {
               "actionType": "BACK_NAVIGATION",
-              "properties": {"name": "HOME", "type": "HOME"}
+              "properties": {
+                "name": "HOME",
+                "type": "HOME"
+              }
             }
           ]
         }
@@ -2549,7 +2680,9 @@ final dynamic sampleSMCFlows = {
       "screenType": "TEMPLATE",
       "description": "REGISTRATION_SEARCH_BENEFICIARY_DESC",
       "initActions": [
-        {"actionType": "LOAD_UNIQUE_ID_POOL"}
+        {
+          "actionType": "LOAD_UNIQUE_ID_POOL"
+        }
       ],
       "wrapperConfig": {
         "filters": [],
@@ -2570,7 +2703,10 @@ final dynamic sampleSMCFlows = {
             },
             "entity": "HouseholdMemberModel",
             "filters": [
-              {"field": "isHeadOfHousehold", "equals": true}
+              {
+                "field": "isHeadOfHousehold",
+                "equals": true
+              }
             ]
           },
           {
@@ -2633,7 +2769,10 @@ final dynamic sampleSMCFlows = {
             "task"
           ],
           "primary": "household",
-          "pagination": {"limit": 5, "maxItems": 15}
+          "pagination": {
+            "limit": 5,
+            "maxItems": 15
+          }
         }
       },
       "scrollListener": {
@@ -2642,7 +2781,10 @@ final dynamic sampleSMCFlows = {
           {
             "actionType": "REFRESH_SEARCH",
             "properties": {
-              "pagination": {"limit": 5, "maxItems": 15}
+              "pagination": {
+                "limit": 5,
+                "maxItems": 15
+              }
             }
           }
         ],
@@ -2651,7 +2793,10 @@ final dynamic sampleSMCFlows = {
           {
             "actionType": "REFRESH_SEARCH",
             "properties": {
-              "pagination": {"limit": 5, "maxItems": 15}
+              "pagination": {
+                "limit": 5,
+                "maxItems": 15
+              }
             }
           }
         ],
@@ -2673,8 +2818,7 @@ final dynamic sampleSMCFlows = {
           "order": 2,
           "footer": [
             {
-              "label":
-                  "APPONE_DELIVERYFLOW_DELIVERYDETAILS_ACTIONS_SUBMIT_LABEL",
+              "label": "APPONE_DELIVERYFLOW_DELIVERYDETAILS_ACTIONS_SUBMIT_LABEL",
               "format": "button",
               "onAction": [
                 {
@@ -2694,8 +2838,7 @@ final dynamic sampleSMCFlows = {
             }
           ],
           "module": "REGISTRATION",
-          "heading":
-              "APPONE_DELIVERYFLOW_DELIVERYDETAILS_ACTIONS_SCREEN_HEADING",
+          "heading": "APPONE_DELIVERYFLOW_DELIVERYDETAILS_ACTIONS_SCREEN_HEADING",
           "summary": false,
           "version": 1,
           "onAction": [
@@ -2705,11 +2848,16 @@ final dynamic sampleSMCFlows = {
                 "data": [
                   {
                     "key": "ProjectBeneficiaryClientReferenceId",
-                    "value":
-                        "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                    "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                   },
-                  {"key": "cycleIndex", "value": "{{navigation.cycleIndex}}"},
-                  {"key": "doseIndex", "value": "{{navigation.doseIndex}}"},
+                  {
+                    "key": "cycleIndex",
+                    "value": "{{navigation.cycleIndex}}"
+                  },
+                  {
+                    "key": "doseIndex",
+                    "value": "{{navigation.doseIndex}}"
+                  },
                   {
                     "key": "deliveryStrategy",
                     "value": "{{navigation.deliveryStrategy}}"
@@ -2732,7 +2880,9 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {"message": "Failed to create delivery task."}
+                    "properties": {
+                      "message": "Failed to create delivery task."
+                    }
                   }
                 ]
               }
@@ -2744,7 +2894,9 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {"message": "Failed to update stock balance."}
+                    "properties": {
+                      "message": "Failed to update stock balance."
+                    }
                   }
                 ]
               }
@@ -2757,8 +2909,7 @@ final dynamic sampleSMCFlows = {
                     "data": [
                       {
                         "key": "ProjectBeneficiaryClientReferenceId",
-                        "value":
-                            "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                        "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                       },
                       {
                         "key": "cycleIndex",
@@ -2813,7 +2964,9 @@ final dynamic sampleSMCFlows = {
                   }
                 }
               ],
-              "condition": {"expression": "doseIndex == 1"}
+              "condition": {
+                "expression": "doseIndex == 1"
+              }
             },
             {
               "actionType": "NAVIGATION",
@@ -2821,8 +2974,7 @@ final dynamic sampleSMCFlows = {
                 "data": [
                   {
                     "key": "ProjectBeneficiaryClientReferenceId",
-                    "value":
-                        "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                    "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                   },
                   {
                     "key": "HouseholdClientReferenceId",
@@ -2913,10 +3065,8 @@ final dynamic sampleSMCFlows = {
               "errorMessage": ""
             }
           ],
-          "actionLabel":
-              "APPONE_DELIVERYFLOW_DELIVERYDETAILS_ACTIONS_SUBMIT_LABEL",
-          "description":
-              "APPONE_DELIVERYFLOW_DELIVERYDETAILS_ACTIONS_SCREEN_DESCRIPTION",
+          "actionLabel": "APPONE_DELIVERYFLOW_DELIVERYDETAILS_ACTIONS_SUBMIT_LABEL",
+          "description": "APPONE_DELIVERYFLOW_DELIVERYDETAILS_ACTIONS_SCREEN_DESCRIPTION",
           "showTabView": false,
           "submitCondition": null,
           "preventScreenCapture": false,
@@ -2931,8 +3081,7 @@ final dynamic sampleSMCFlows = {
           "order": 1,
           "footer": [
             {
-              "label":
-                  "APPONE_REGISTRATION_DELIVERYDETAILS_ACTION_BUTTON_LABEL_1",
+              "label": "APPONE_REGISTRATION_DELIVERYDETAILS_ACTION_BUTTON_LABEL_1",
               "format": "button",
               "onAction": [
                 {
@@ -2962,11 +3111,16 @@ final dynamic sampleSMCFlows = {
                 "data": [
                   {
                     "key": "ProjectBeneficiaryClientReferenceId",
-                    "value":
-                        "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                    "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                   },
-                  {"key": "cycleIndex", "value": "{{navigation.cycleIndex}}"},
-                  {"key": "doseIndex", "value": "{{navigation.doseIndex}}"},
+                  {
+                    "key": "cycleIndex",
+                    "value": "{{navigation.cycleIndex}}"
+                  },
+                  {
+                    "key": "doseIndex",
+                    "value": "{{navigation.doseIndex}}"
+                  },
                   {
                     "key": "deliveryStrategy",
                     "value": "{{navigation.deliveryStrategy}}"
@@ -2989,7 +3143,9 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {"message": "Failed to create delivery task."}
+                    "properties": {
+                      "message": "Failed to create delivery task."
+                    }
                   }
                 ]
               }
@@ -3001,7 +3157,9 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {"message": "Failed to update stock balance."}
+                    "properties": {
+                      "message": "Failed to update stock balance."
+                    }
                   }
                 ]
               }
@@ -3014,8 +3172,7 @@ final dynamic sampleSMCFlows = {
                     "data": [
                       {
                         "key": "ProjectBeneficiaryClientReferenceId",
-                        "value":
-                            "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                        "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                       },
                       {
                         "key": "cycleIndex",
@@ -3070,7 +3227,9 @@ final dynamic sampleSMCFlows = {
                   }
                 }
               ],
-              "condition": {"expression": "doseIndex == 1"}
+              "condition": {
+                "expression": "doseIndex == 1"
+              }
             },
             {
               "actionType": "NAVIGATION",
@@ -3078,8 +3237,7 @@ final dynamic sampleSMCFlows = {
                 "data": [
                   {
                     "key": "ProjectBeneficiaryClientReferenceId",
-                    "value":
-                        "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                    "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                   },
                   {
                     "key": "HouseholdClientReferenceId",
@@ -3091,7 +3249,9 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {"message": "Navigation failed."}
+                    "properties": {
+                      "message": "Navigation failed."
+                    }
                   }
                 ],
                 "navigationMode": "popUntilAndPush",
@@ -3099,12 +3259,14 @@ final dynamic sampleSMCFlows = {
               }
             }
           ],
-          "navigateTo": {"name": "DeliveryChecklist", "type": "template"},
+          "navigateTo": {
+            "name": "DeliveryChecklist",
+            "type": "template"
+          },
           "properties": [
             {
               "type": "string",
-              "label":
-                  "APPONE_REGISTRATION_DELIVERYDETAILS_label_dateOfDelivery",
+              "label": "APPONE_REGISTRATION_DELIVERYDETAILS_label_dateOfDelivery",
               "order": 1,
               "value": "",
               "format": "date",
@@ -3129,10 +3291,22 @@ final dynamic sampleSMCFlows = {
             {
               "type": "dynamic",
               "enums": [
-                {"code": "SP1", "name": "SP1"},
-                {"code": "SP2", "name": "SP2"},
-                {"code": "AQ1", "name": "AQ1"},
-                {"code": "AQ2", "name": "AQ2"}
+                {
+                  "code": "SP1",
+                  "name": "SP1"
+                },
+                {
+                  "code": "SP2",
+                  "name": "SP2"
+                },
+                {
+                  "code": "AQ1",
+                  "name": "AQ1"
+                },
+                {
+                  "code": "AQ2",
+                  "name": "AQ2"
+                }
               ],
               "label": "APPONE_REGISTRATION_DELIVERYDETAILS_label_resource",
               "order": 2,
@@ -3162,20 +3336,30 @@ final dynamic sampleSMCFlows = {
               "includeInForm": true,
               "isMultiSelect": false,
               "dropDownOptions": [
-                {"code": "SP1", "name": "SP1"},
-                {"code": "SP2", "name": "SP2"},
-                {"code": "AQ1", "name": "AQ1"},
-                {"code": "AQ2", "name": "AQ2"}
+                {
+                  "code": "SP1",
+                  "name": "SP1"
+                },
+                {
+                  "code": "SP2",
+                  "name": "SP2"
+                },
+                {
+                  "code": "AQ1",
+                  "name": "AQ1"
+                },
+                {
+                  "code": "AQ2",
+                  "name": "AQ2"
+                }
               ],
               "includeInSummary": true,
-              "required.message":
-                  "REGISTRATION_RESOURCE_CARD_SELECTION_REQUIRED"
+              "required.message": "REGISTRATION_RESOURCE_CARD_SELECTION_REQUIRED"
             },
             {
               "type": "string",
               "enums": null,
-              "label":
-                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_deliveryComments",
+              "label": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_deliveryComments",
               "order": 3,
               "value": "",
               "format": "dropdown",
@@ -3198,10 +3382,8 @@ final dynamic sampleSMCFlows = {
               "includeInSummary": true
             }
           ],
-          "actionLabel":
-              "APPONE_REGISTRATION_DELIVERYDETAILS_ACTION_BUTTON_LABEL_1",
-          "description":
-              "APPONE_REGISTRATION_DELIVERYDETAILS_SCREEN_DESCRIPTION",
+          "actionLabel": "APPONE_REGISTRATION_DELIVERYDETAILS_ACTION_BUTTON_LABEL_1",
+          "description": "APPONE_REGISTRATION_DELIVERYDETAILS_SCREEN_DESCRIPTION",
           "showTabView": false,
           "submitCondition": null,
           "preventScreenCapture": false
@@ -3220,8 +3402,14 @@ final dynamic sampleSMCFlows = {
                 "key": "ProjectBeneficiaryClientReferenceId",
                 "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
               },
-              {"key": "cycleIndex", "value": "{{navigation.cycleIndex}}"},
-              {"key": "doseIndex", "value": "{{navigation.doseIndex}}"},
+              {
+                "key": "cycleIndex",
+                "value": "{{navigation.cycleIndex}}"
+              },
+              {
+                "key": "doseIndex",
+                "value": "{{navigation.doseIndex}}"
+              },
               {
                 "key": "deliveryStrategy",
                 "value": "{{navigation.deliveryStrategy}}"
@@ -3230,7 +3418,9 @@ final dynamic sampleSMCFlows = {
             "onError": [
               {
                 "actionType": "SHOW_TOAST",
-                "properties": {"message": "REGISTRATION_DELIVERY_MESSAGE"}
+                "properties": {
+                  "message": "REGISTRATION_DELIVERY_MESSAGE"
+                }
               }
             ],
             "configName": "delivery"
@@ -3242,7 +3432,9 @@ final dynamic sampleSMCFlows = {
             "onError": [
               {
                 "actionType": "SHOW_TOAST",
-                "properties": {"message": "Failed to create delivery task."}
+                "properties": {
+                  "message": "Failed to create delivery task."
+                }
               }
             ]
           }
@@ -3254,7 +3446,9 @@ final dynamic sampleSMCFlows = {
             "onError": [
               {
                 "actionType": "SHOW_TOAST",
-                "properties": {"message": "Failed to update stock balance."}
+                "properties": {
+                  "message": "Failed to update stock balance."
+                }
               }
             ]
           }
@@ -3267,15 +3461,20 @@ final dynamic sampleSMCFlows = {
                 "data": [
                   {
                     "key": "ProjectBeneficiaryClientReferenceId",
-                    "value":
-                        "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                    "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                   },
-                  {"key": "cycleIndex", "value": "{{navigation.cycleIndex}}"},
+                  {
+                    "key": "cycleIndex",
+                    "value": "{{navigation.cycleIndex}}"
+                  },
                   {
                     "key": "deliveryStrategy",
                     "value": "{{navigation.deliveryStrategy}}"
                   },
-                  {"key": "futureDoses", "value": "{{navigation.futureDoses}}"}
+                  {
+                    "key": "futureDoses",
+                    "value": "{{navigation.futureDoses}}"
+                  }
                 ],
                 "onError": [
                   {
@@ -3295,7 +3494,9 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {"message": "Failed to create bulk tasks."}
+                    "properties": {
+                      "message": "Failed to create bulk tasks."
+                    }
                   }
                 ]
               }
@@ -3307,13 +3508,17 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {"message": "Failed to update stock balance."}
+                    "properties": {
+                      "message": "Failed to update stock balance."
+                    }
                   }
                 ]
               }
             }
           ],
-          "condition": {"expression": "doseIndex == 1"}
+          "condition": {
+            "expression": "doseIndex == 1"
+          }
         },
         {
           "actionType": "NAVIGATION",
@@ -3333,7 +3538,9 @@ final dynamic sampleSMCFlows = {
             "onError": [
               {
                 "actionType": "SHOW_TOAST",
-                "properties": {"message": "Navigation failed."}
+                "properties": {
+                  "message": "Navigation failed."
+                }
               }
             ],
             "navigationMode": "popUntilAndPush",
@@ -3390,10 +3597,12 @@ final dynamic sampleSMCFlows = {
                 "data": [
                   {
                     "key": "ProjectBeneficiaryClientReferenceId",
-                    "value":
-                        "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                    "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                   },
-                  {"key": "cycleIndex", "value": "{{navigation.cycleIndex}}"},
+                  {
+                    "key": "cycleIndex",
+                    "value": "{{navigation.cycleIndex}}"
+                  },
                   {
                     "key": "lastDeliveredTaskClientReferenceId",
                     "value": "{{navigation.lastDeliveredTaskClientReferenceId}}"
@@ -3418,7 +3627,9 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {"message": "Failed to create redose task."}
+                    "properties": {
+                      "message": "Failed to create redose task."
+                    }
                   }
                 ]
               }
@@ -3430,7 +3641,9 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {"message": "Failed to update stock balance."}
+                    "properties": {
+                      "message": "Failed to update stock balance."
+                    }
                   }
                 ]
               }
@@ -3441,8 +3654,7 @@ final dynamic sampleSMCFlows = {
                 "data": [
                   {
                     "key": "ProjectBeneficiaryClientReferenceId",
-                    "value":
-                        "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                    "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                   },
                   {
                     "key": "HouseholdClientReferenceId",
@@ -3493,10 +3705,22 @@ final dynamic sampleSMCFlows = {
             {
               "type": "dynamic",
               "enums": [
-                {"code": "SP1", "name": "SP1"},
-                {"code": "SP2", "name": "SP2"},
-                {"code": "AQ1", "name": "AQ1"},
-                {"code": "AQ2", "name": "AQ2"}
+                {
+                  "code": "SP1",
+                  "name": "SP1"
+                },
+                {
+                  "code": "SP2",
+                  "name": "SP2"
+                },
+                {
+                  "code": "AQ1",
+                  "name": "AQ1"
+                },
+                {
+                  "code": "AQ2",
+                  "name": "AQ2"
+                }
               ],
               "label": "REDOSE_RESOURCE_DELIVERED",
               "order": 2,
@@ -3520,18 +3744,36 @@ final dynamic sampleSMCFlows = {
               "includeInForm": true,
               "isMultiSelect": false,
               "dropDownOptions": [
-                {"code": "SP1", "name": "SP1"},
-                {"code": "SP2", "name": "SP2"},
-                {"code": "AQ1", "name": "AQ1"},
-                {"code": "AQ2", "name": "AQ2"}
+                {
+                  "code": "SP1",
+                  "name": "SP1"
+                },
+                {
+                  "code": "SP2",
+                  "name": "SP2"
+                },
+                {
+                  "code": "AQ1",
+                  "name": "AQ1"
+                },
+                {
+                  "code": "AQ2",
+                  "name": "AQ2"
+                }
               ],
               "includeInSummary": true
             },
             {
               "type": "string",
               "enums": [
-                {"code": "VOMITTING", "name": "REDOSE_REASON_VOMITTING"},
-                {"code": "OTHERS", "name": "REDOSE_REASON_OTHERS"}
+                {
+                  "code": "VOMITTING",
+                  "name": "REDOSE_REASON_VOMITTING"
+                },
+                {
+                  "code": "OTHERS",
+                  "name": "REDOSE_REASON_OTHERS"
+                }
               ],
               "label": "REDOSE_REASON",
               "order": 3,
@@ -3586,7 +3828,9 @@ final dynamic sampleSMCFlows = {
               "includeInSummary": true,
               "visibilityCondition": {
                 "expression": [
-                  {"condition": "RedoseDetails.reasonForRedose==OTHERS"}
+                  {
+                    "condition": "RedoseDetails.reasonForRedose==OTHERS"
+                  }
                 ]
               }
             }
@@ -3612,7 +3856,10 @@ final dynamic sampleSMCFlows = {
                 "key": "ProjectBeneficiaryClientReferenceId",
                 "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
               },
-              {"key": "cycleIndex", "value": "{{navigation.cycleIndex}}"},
+              {
+                "key": "cycleIndex",
+                "value": "{{navigation.cycleIndex}}"
+              },
               {
                 "key": "lastDeliveredTaskClientReferenceId",
                 "value": "{{navigation.lastDeliveredTaskClientReferenceId}}"
@@ -3621,7 +3868,9 @@ final dynamic sampleSMCFlows = {
             "onError": [
               {
                 "actionType": "SHOW_TOAST",
-                "properties": {"message": "REGISTRATION_REDOSE_MESSAGE"}
+                "properties": {
+                  "message": "REGISTRATION_REDOSE_MESSAGE"
+                }
               }
             ],
             "configName": "redose"
@@ -3635,7 +3884,9 @@ final dynamic sampleSMCFlows = {
             "onError": [
               {
                 "actionType": "SHOW_TOAST",
-                "properties": {"message": "Failed to create redose task."}
+                "properties": {
+                  "message": "Failed to create redose task."
+                }
               }
             ]
           }
@@ -3674,7 +3925,9 @@ final dynamic sampleSMCFlows = {
             "onError": [
               {
                 "actionType": "SHOW_TOAST",
-                "properties": {"message": "Navigation failed."}
+                "properties": {
+                  "message": "Navigation failed."
+                }
               }
             ],
             "navigationMode": "popUntilAndPush",
@@ -3701,8 +3954,7 @@ final dynamic sampleSMCFlows = {
           "order": 1,
           "footer": [
             {
-              "label":
-                  "APPONE_REGISTRATION_DELIVERYDETAILS_ACTION_BUTTON_LABEL_1",
+              "label": "APPONE_REGISTRATION_DELIVERYDETAILS_ACTION_BUTTON_LABEL_1",
               "format": "button",
               "onAction": [
                 {
@@ -3734,8 +3986,7 @@ final dynamic sampleSMCFlows = {
                     "data": [
                       {
                         "key": "selectedIndividualClientReferenceId",
-                        "value":
-                            "{{navigation.selectedIndividualClientReferenceId}}"
+                        "value": "{{navigation.selectedIndividualClientReferenceId}}"
                       },
                       {
                         "key": "selectedIndividualIdentifierId",
@@ -3747,8 +3998,7 @@ final dynamic sampleSMCFlows = {
                       },
                       {
                         "key": "ProjectBeneficiaryClientReferenceId",
-                        "value":
-                            "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                        "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                       }
                     ],
                     "name": "beneficiaryDetails",
@@ -3767,8 +4017,7 @@ final dynamic sampleSMCFlows = {
                 }
               ],
               "condition": {
-                "expression":
-                    "eligibilityChecklist.ec1==NO && eligibilityChecklist.ec3==NO && eligibilityChecklist.ec4==NO"
+                "expression": "eligibilityChecklist.ec1==NO && eligibilityChecklist.ec3==NO && eligibilityChecklist.ec4==NO"
               }
             },
             {
@@ -3779,8 +4028,7 @@ final dynamic sampleSMCFlows = {
                     "data": [
                       {
                         "key": "selectedIndividualClientReferenceId",
-                        "value":
-                            "{{navigation.selectedIndividualClientReferenceId}}"
+                        "value": "{{navigation.selectedIndividualClientReferenceId}}"
                       },
                       {
                         "key": "selectedIndividualIdentifierId",
@@ -3792,8 +4040,7 @@ final dynamic sampleSMCFlows = {
                       },
                       {
                         "key": "ProjectBeneficiaryClientReferenceId",
-                        "value":
-                            "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                        "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                       },
                       {
                         "key": "selectedIndividualName",
@@ -3828,8 +4075,7 @@ final dynamic sampleSMCFlows = {
                 }
               ],
               "condition": {
-                "expression":
-                    "eligibilityChecklist.ec1==YES && eligibilityChecklist.ec3==YES && eligibilityChecklist.ec4==YES"
+                "expression": "eligibilityChecklist.ec1==YES && eligibilityChecklist.ec3==YES && eligibilityChecklist.ec4==YES"
               }
             },
             {
@@ -3840,8 +4086,7 @@ final dynamic sampleSMCFlows = {
                     "data": [
                       {
                         "key": "selectedIndividualClientReferenceId",
-                        "value":
-                            "{{navigation.selectedIndividualClientReferenceId}}"
+                        "value": "{{navigation.selectedIndividualClientReferenceId}}"
                       },
                       {
                         "key": "selectedIndividualIdentifierId",
@@ -3853,8 +4098,7 @@ final dynamic sampleSMCFlows = {
                       },
                       {
                         "key": "ProjectBeneficiaryClientReferenceId",
-                        "value":
-                            "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                        "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                       }
                     ],
                     "onError": [
@@ -3888,8 +4132,7 @@ final dynamic sampleSMCFlows = {
                     "data": [
                       {
                         "key": "selectedIndividualClientReferenceId",
-                        "value":
-                            "{{navigation.selectedIndividualClientReferenceId}}"
+                        "value": "{{navigation.selectedIndividualClientReferenceId}}"
                       },
                       {
                         "key": "selectedIndividualIdentifierId",
@@ -3901,8 +4144,7 @@ final dynamic sampleSMCFlows = {
                       },
                       {
                         "key": "ProjectBeneficiaryClientReferenceId",
-                        "value":
-                            "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                        "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                       }
                     ],
                     "name": "householdOverview",
@@ -3910,7 +4152,9 @@ final dynamic sampleSMCFlows = {
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {"message": "Navigation to flow failed."}
+                        "properties": {
+                          "message": "Navigation to flow failed."
+                        }
                       }
                     ],
                     "navigationMode": "popUntilAndPush",
@@ -3919,8 +4163,7 @@ final dynamic sampleSMCFlows = {
                 }
               ],
               "condition": {
-                "expression":
-                    "eligibilityChecklist.ec1==NO && eligibilityChecklist.ec3==NO && eligibilityChecklist.ec4==YES"
+                "expression": "eligibilityChecklist.ec1==NO && eligibilityChecklist.ec3==NO && eligibilityChecklist.ec4==YES"
               }
             },
             {
@@ -3931,8 +4174,7 @@ final dynamic sampleSMCFlows = {
                     "data": [
                       {
                         "key": "selectedIndividualClientReferenceId",
-                        "value":
-                            "{{navigation.selectedIndividualClientReferenceId}}"
+                        "value": "{{navigation.selectedIndividualClientReferenceId}}"
                       },
                       {
                         "key": "selectedIndividualIdentifierId",
@@ -3944,8 +4186,7 @@ final dynamic sampleSMCFlows = {
                       },
                       {
                         "key": "ProjectBeneficiaryClientReferenceId",
-                        "value":
-                            "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                        "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                       },
                       {
                         "key": "selectedIndividualName",
@@ -3969,7 +4210,9 @@ final dynamic sampleSMCFlows = {
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {"message": "Navigation failed."}
+                        "properties": {
+                          "message": "Navigation failed."
+                        }
                       }
                     ],
                     "navigationMode": "popUntilAndPush",
@@ -3977,7 +4220,9 @@ final dynamic sampleSMCFlows = {
                   }
                 }
               ],
-              "condition": {"expression": "DEFAULT"}
+              "condition": {
+                "expression": "DEFAULT"
+              }
             }
           ],
           "navigateTo": {
@@ -3988,8 +4233,14 @@ final dynamic sampleSMCFlows = {
             {
               "type": "string",
               "enums": [
-                {"code": "YES", "name": "QUESTION_1_YES"},
-                {"code": "NO", "name": "QUESTION_1_NO"}
+                {
+                  "code": "YES",
+                  "name": "QUESTION_1_YES"
+                },
+                {
+                  "code": "NO",
+                  "name": "QUESTION_1_NO"
+                }
               ],
               "label": "APPONE_ELIGIBILITYCHECKLIST_QUESTION_1_LABEL",
               "order": 1,
@@ -4012,26 +4263,36 @@ final dynamic sampleSMCFlows = {
                 {
                   "type": "required",
                   "value": true,
-                  "message":
-                      "APPONE_ELIGIBILITYCHECKLIST_QUESTION_1_LABEL_REQUIRED_MESSAGE"
+                  "message": "APPONE_ELIGIBILITYCHECKLIST_QUESTION_1_LABEL_REQUIRED_MESSAGE"
                 }
               ],
               "errorMessage": "REGISTRATION_CHECKLIST_ec1_ERROR",
               "includeInForm": true,
               "isMultiSelect": false,
               "dropDownOptions": [
-                {"code": "YES", "name": "QUESTION_1_YES"},
-                {"code": "NO", "name": "QUESTION_1_NO"}
+                {
+                  "code": "YES",
+                  "name": "QUESTION_1_YES"
+                },
+                {
+                  "code": "NO",
+                  "name": "QUESTION_1_NO"
+                }
               ],
               "includeInSummary": true,
-              "required.message":
-                  "APPONE_ELIGIBILITYCHECKLIST_QUESTION_1_LABEL_REQUIRED_MESSAGE"
+              "required.message": "APPONE_ELIGIBILITYCHECKLIST_QUESTION_1_LABEL_REQUIRED_MESSAGE"
             },
             {
               "type": "string",
               "enums": [
-                {"code": "YES", "name": "QUESTION_2_YES"},
-                {"code": "NO", "name": "QUESTION_2_NO"}
+                {
+                  "code": "YES",
+                  "name": "QUESTION_2_YES"
+                },
+                {
+                  "code": "NO",
+                  "name": "QUESTION_2_NO"
+                }
               ],
               "label": "APPONE_ELIGIBILITYCHECKLIST_QUESTION_2_LABEL",
               "order": 2,
@@ -4054,31 +4315,43 @@ final dynamic sampleSMCFlows = {
                 {
                   "type": "required",
                   "value": true,
-                  "message":
-                      "APPONE_ELIGIBILITYCHECKLIST_QUESTION_2_LABEL_REQUIRED_MESSAGE"
+                  "message": "APPONE_ELIGIBILITYCHECKLIST_QUESTION_2_LABEL_REQUIRED_MESSAGE"
                 }
               ],
               "errorMessage": "REGISTRATION_CHECKLIST_ec2_ERROR",
               "includeInForm": true,
               "isMultiSelect": false,
               "dropDownOptions": [
-                {"code": "YES", "name": "QUESTION_2_YES"},
-                {"code": "NO", "name": "QUESTION_2_NO"}
+                {
+                  "code": "YES",
+                  "name": "QUESTION_2_YES"
+                },
+                {
+                  "code": "NO",
+                  "name": "QUESTION_2_NO"
+                }
               ],
               "includeInSummary": true,
-              "required.message":
-                  "APPONE_ELIGIBILITYCHECKLIST_QUESTION_2_LABEL_REQUIRED_MESSAGE",
+              "required.message": "APPONE_ELIGIBILITYCHECKLIST_QUESTION_2_LABEL_REQUIRED_MESSAGE",
               "visibilityCondition": {
                 "expression": [
-                  {"condition": "eligibilityChecklist.ec1==YES"}
+                  {
+                    "condition": "eligibilityChecklist.ec1==YES"
+                  }
                 ]
               }
             },
             {
               "type": "string",
               "enums": [
-                {"code": "YES", "name": "QUESTION_3_YES"},
-                {"code": "NO", "name": "QUESTION_3_NO"}
+                {
+                  "code": "YES",
+                  "name": "QUESTION_3_YES"
+                },
+                {
+                  "code": "NO",
+                  "name": "QUESTION_3_NO"
+                }
               ],
               "label": "APPONE_ELIGIBILITYCHECKLIST_QUESTION_3_LABEL",
               "order": 3,
@@ -4101,26 +4374,36 @@ final dynamic sampleSMCFlows = {
                 {
                   "type": "required",
                   "value": true,
-                  "message":
-                      "APPONE_ELIGIBILITYCHECKLIST_QUESTION_3_LABEL_REQUIRED_MESSAGE"
+                  "message": "APPONE_ELIGIBILITYCHECKLIST_QUESTION_3_LABEL_REQUIRED_MESSAGE"
                 }
               ],
               "errorMessage": "REGISTRATION_CHECKLIST_ec3_ERROR",
               "includeInForm": true,
               "isMultiSelect": false,
               "dropDownOptions": [
-                {"code": "YES", "name": "QUESTION_3_YES"},
-                {"code": "NO", "name": "QUESTION_3_NO"}
+                {
+                  "code": "YES",
+                  "name": "QUESTION_3_YES"
+                },
+                {
+                  "code": "NO",
+                  "name": "QUESTION_3_NO"
+                }
               ],
               "includeInSummary": true,
-              "required.message":
-                  "APPONE_ELIGIBILITYCHECKLIST_QUESTION_3_LABEL_REQUIRED_MESSAGE"
+              "required.message": "APPONE_ELIGIBILITYCHECKLIST_QUESTION_3_LABEL_REQUIRED_MESSAGE"
             },
             {
               "type": "string",
               "enums": [
-                {"code": "YES", "name": "QUESTION_4_YES"},
-                {"code": "NO", "name": "QUESTION_4_NO"}
+                {
+                  "code": "YES",
+                  "name": "QUESTION_4_YES"
+                },
+                {
+                  "code": "NO",
+                  "name": "QUESTION_4_NO"
+                }
               ],
               "label": "APPONE_ELIGIBILITYCHECKLIST_QUESTION_4_LABEL",
               "order": 3,
@@ -4143,24 +4426,27 @@ final dynamic sampleSMCFlows = {
                 {
                   "type": "required",
                   "value": true,
-                  "message":
-                      "APPONE_ELIGIBILITYCHECKLIST_QUESTION_4_LABEL_REQUIRED_MESSAGE"
+                  "message": "APPONE_ELIGIBILITYCHECKLIST_QUESTION_4_LABEL_REQUIRED_MESSAGE"
                 }
               ],
               "errorMessage": "REGISTRATION_CHECKLIST_ec4_ERROR",
               "includeInForm": true,
               "isMultiSelect": false,
               "dropDownOptions": [
-                {"code": "YES", "name": "QUESTION_4_YES"},
-                {"code": "NO", "name": "QUESTION_4_NO"}
+                {
+                  "code": "YES",
+                  "name": "QUESTION_4_YES"
+                },
+                {
+                  "code": "NO",
+                  "name": "QUESTION_4_NO"
+                }
               ],
               "includeInSummary": true,
-              "required.message":
-                  "APPONE_ELIGIBILITYCHECKLIST_QUESTION_4_LABEL_REQUIRED_MESSAGE"
+              "required.message": "APPONE_ELIGIBILITYCHECKLIST_QUESTION_4_LABEL_REQUIRED_MESSAGE"
             }
           ],
-          "actionLabel":
-              "APPONE_REGISTRATION_DELIVERYDETAILS_ACTION_BUTTON_LABEL_1",
+          "actionLabel": "APPONE_REGISTRATION_DELIVERYDETAILS_ACTION_BUTTON_LABEL_1",
           "description": "APPONE_ELIGIBILITY_CHECKLIST_SCREEN_DESCRIPTION",
           "showTabView": false,
           "showAlertPopUp": {
@@ -4168,15 +4454,16 @@ final dynamic sampleSMCFlows = {
             "conditions": [
               {
                 "value": "To Administer",
-                "expression":
-                    "eligibilityChecklist.ec1==NO && eligibilityChecklist.ec3==NO && eligibilityChecklist.ec4==NO"
+                "expression": "eligibilityChecklist.ec1==NO && eligibilityChecklist.ec3==NO && eligibilityChecklist.ec4==NO"
               },
               {
                 "value": "Ineligible flow",
-                "expression":
-                    "eligibilityChecklist.ec1==NO && eligibilityChecklist.ec3==NO && eligibilityChecklist.ec4==YES"
+                "expression": "eligibilityChecklist.ec1==NO && eligibilityChecklist.ec3==NO && eligibilityChecklist.ec4==YES"
               },
-              {"value": "referral flow", "expression": "DEFAULT"}
+              {
+                "value": "referral flow",
+                "expression": "DEFAULT"
+              }
             ],
             "description": "APPONE_ELIGIBILITYCHECKLIST_ALERT_DESCRIPTION",
             "primaryActionLabel": "ACTION_SUBMIT",
@@ -4199,8 +4486,7 @@ final dynamic sampleSMCFlows = {
                 "data": [
                   {
                     "key": "selectedIndividualClientReferenceId",
-                    "value":
-                        "{{navigation.selectedIndividualClientReferenceId}}"
+                    "value": "{{navigation.selectedIndividualClientReferenceId}}"
                   },
                   {
                     "key": "selectedIndividualIdentifierId",
@@ -4212,8 +4498,7 @@ final dynamic sampleSMCFlows = {
                   },
                   {
                     "key": "ProjectBeneficiaryClientReferenceId",
-                    "value":
-                        "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                    "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                   }
                 ],
                 "name": "beneficiaryDetails",
@@ -4221,7 +4506,9 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {"message": "Navigation failed."}
+                    "properties": {
+                      "message": "Navigation failed."
+                    }
                   }
                 ],
                 "navigationMode": "popUntilAndPush",
@@ -4230,8 +4517,7 @@ final dynamic sampleSMCFlows = {
             }
           ],
           "condition": {
-            "expression":
-                "eligibilityChecklist.ec1==NO && eligibilityChecklist.ec3==NO && eligibilityChecklist.ec4==NO"
+            "expression": "eligibilityChecklist.ec1==NO && eligibilityChecklist.ec3==NO && eligibilityChecklist.ec4==NO"
           }
         },
         {
@@ -4242,8 +4528,7 @@ final dynamic sampleSMCFlows = {
                 "data": [
                   {
                     "key": "selectedIndividualClientReferenceId",
-                    "value":
-                        "{{navigation.selectedIndividualClientReferenceId}}"
+                    "value": "{{navigation.selectedIndividualClientReferenceId}}"
                   },
                   {
                     "key": "selectedIndividualIdentifierId",
@@ -4255,8 +4540,7 @@ final dynamic sampleSMCFlows = {
                   },
                   {
                     "key": "ProjectBeneficiaryClientReferenceId",
-                    "value":
-                        "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                    "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                   },
                   {
                     "key": "selectedIndividualName",
@@ -4270,14 +4554,19 @@ final dynamic sampleSMCFlows = {
                     "key": "selectedIndividualAgeInMonths",
                     "value": "{{navigation.selectedIndividualAgeInMonths}}"
                   },
-                  {"key": "cycleIndex", "value": "{{navigation.cycleIndex}}"}
+                  {
+                    "key": "cycleIndex",
+                    "value": "{{navigation.cycleIndex}}"
+                  }
                 ],
                 "name": "REFER_BENEFICIARY",
                 "type": "FORM",
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {"message": "Navigation failed."}
+                    "properties": {
+                      "message": "Navigation failed."
+                    }
                   }
                 ],
                 "navigationMode": "popUntilAndPush",
@@ -4286,8 +4575,7 @@ final dynamic sampleSMCFlows = {
             }
           ],
           "condition": {
-            "expression":
-                "eligibilityChecklist.ec1==YES && eligibilityChecklist.ec3==YES && eligibilityChecklist.ec4==YES"
+            "expression": "eligibilityChecklist.ec1==YES && eligibilityChecklist.ec3==YES && eligibilityChecklist.ec4==YES"
           }
         },
         {
@@ -4298,8 +4586,7 @@ final dynamic sampleSMCFlows = {
                 "data": [
                   {
                     "key": "selectedIndividualClientReferenceId",
-                    "value":
-                        "{{navigation.selectedIndividualClientReferenceId}}"
+                    "value": "{{navigation.selectedIndividualClientReferenceId}}"
                   },
                   {
                     "key": "selectedIndividualIdentifierId",
@@ -4311,14 +4598,15 @@ final dynamic sampleSMCFlows = {
                   },
                   {
                     "key": "ProjectBeneficiaryClientReferenceId",
-                    "value":
-                        "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                    "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                   }
                 ],
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {"message": "REGISTRATION_CHECKLIST_MESSAGE"}
+                    "properties": {
+                      "message": "REGISTRATION_CHECKLIST_MESSAGE"
+                    }
                   }
                 ],
                 "configName": "ineligibleConfig"
@@ -4331,7 +4619,9 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {"message": "Failed to create task records."}
+                    "properties": {
+                      "message": "Failed to create task records."
+                    }
                   }
                 ]
               }
@@ -4342,8 +4632,7 @@ final dynamic sampleSMCFlows = {
                 "data": [
                   {
                     "key": "selectedIndividualClientReferenceId",
-                    "value":
-                        "{{navigation.selectedIndividualClientReferenceId}}"
+                    "value": "{{navigation.selectedIndividualClientReferenceId}}"
                   },
                   {
                     "key": "selectedIndividualIdentifierId",
@@ -4355,8 +4644,7 @@ final dynamic sampleSMCFlows = {
                   },
                   {
                     "key": "ProjectBeneficiaryClientReferenceId",
-                    "value":
-                        "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                    "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                   }
                 ],
                 "name": "householdOverview",
@@ -4364,7 +4652,9 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {"message": "Navigation to flow failed."}
+                    "properties": {
+                      "message": "Navigation to flow failed."
+                    }
                   }
                 ],
                 "navigationMode": "popUntilAndPush",
@@ -4373,8 +4663,7 @@ final dynamic sampleSMCFlows = {
             }
           ],
           "condition": {
-            "expression":
-                "eligibilityChecklist.ec1==NO && eligibilityChecklist.ec3==NO && eligibilityChecklist.ec4==YES"
+            "expression": "eligibilityChecklist.ec1==NO && eligibilityChecklist.ec3==NO && eligibilityChecklist.ec4==YES"
           }
         },
         {
@@ -4385,8 +4674,7 @@ final dynamic sampleSMCFlows = {
                 "data": [
                   {
                     "key": "selectedIndividualClientReferenceId",
-                    "value":
-                        "{{navigation.selectedIndividualClientReferenceId}}"
+                    "value": "{{navigation.selectedIndividualClientReferenceId}}"
                   },
                   {
                     "key": "selectedIndividualIdentifierId",
@@ -4398,8 +4686,7 @@ final dynamic sampleSMCFlows = {
                   },
                   {
                     "key": "ProjectBeneficiaryClientReferenceId",
-                    "value":
-                        "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                    "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                   },
                   {
                     "key": "selectedIndividualName",
@@ -4413,14 +4700,19 @@ final dynamic sampleSMCFlows = {
                     "key": "selectedIndividualAgeInMonths",
                     "value": "{{navigation.selectedIndividualAgeInMonths}}"
                   },
-                  {"key": "cycleIndex", "value": "{{navigation.cycleIndex}}"}
+                  {
+                    "key": "cycleIndex",
+                    "value": "{{navigation.cycleIndex}}"
+                  }
                 ],
                 "name": "REFER_BENEFICIARY",
                 "type": "FORM",
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {"message": "Navigation failed."}
+                    "properties": {
+                      "message": "Navigation failed."
+                    }
                   }
                 ],
                 "navigationMode": "popUntilAndPush",
@@ -4428,7 +4720,9 @@ final dynamic sampleSMCFlows = {
               }
             }
           ],
-          "condition": {"expression": "DEFAULT"}
+          "condition": {
+            "expression": "DEFAULT"
+          }
         }
       ],
       "isSelected": true,
@@ -4446,13 +4740,11 @@ final dynamic sampleSMCFlows = {
           "flow": "ADD_MEMBER",
           "page": "beneficiaryDetails",
           "type": "object",
-          "label":
-              "APPONE_REGISTRATION_BENEFICIARYDETAILS_SCREEN_HEADING_addmember",
+          "label": "APPONE_REGISTRATION_BENEFICIARYDETAILS_SCREEN_HEADING_addmember",
           "order": 4,
           "footer": [
             {
-              "label":
-                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_ACTION_BUTTON_LABEL_addmember",
+              "label": "APPONE_REGISTRATION_BENEFICIARYDETAILS_ACTION_BUTTON_LABEL_addmember",
               "format": "button",
               "onAction": [
                 {
@@ -4478,8 +4770,7 @@ final dynamic sampleSMCFlows = {
             }
           ],
           "module": "REGISTRATION",
-          "heading":
-              "APPONE_REGISTRATION_BENEFICIARYDETAILS_SCREEN_HEADING_addmember",
+          "heading": "APPONE_REGISTRATION_BENEFICIARYDETAILS_SCREEN_HEADING_addmember",
           "summary": false,
           "version": 1,
           "onAction": [
@@ -4495,7 +4786,9 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {"message": "Failed to fetch config."}
+                    "properties": {
+                      "message": "Failed to fetch config."
+                    }
                   }
                 ],
                 "configName": "individualRegistration"
@@ -4510,7 +4803,10 @@ final dynamic sampleSMCFlows = {
                   }
                 }
               ],
-              "condition": {"type": "custom", "expression": "isEdit == true"}
+              "condition": {
+                "type": "custom",
+                "expression": "isEdit == true"
+              }
             },
             {
               "actions": [
@@ -4521,7 +4817,9 @@ final dynamic sampleSMCFlows = {
                   }
                 }
               ],
-              "condition": {"expression": "DEFAULT"}
+              "condition": {
+                "expression": "DEFAULT"
+              }
             },
             {
               "actionType": "NAVIGATION",
@@ -4537,7 +4835,9 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {"message": "Navigation failed."}
+                    "properties": {
+                      "message": "Navigation failed."
+                    }
                   }
                 ],
                 "navigationMode": "popUntilAndPush",
@@ -4558,16 +4858,14 @@ final dynamic sampleSMCFlows = {
           "properties": [
             {
               "type": "string",
-              "label":
-                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_addmember",
+              "label": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_addmember",
               "order": 1,
               "value": "",
               "format": "text",
               "hidden": false,
               "isMdms": false,
               "tooltip": "",
-              "helpText":
-                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_helpText_addmember",
+              "helpText": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_helpText_addmember",
               "infoText": "",
               "readOnly": false,
               "required": true,
@@ -4580,45 +4878,42 @@ final dynamic sampleSMCFlows = {
               "lengthRange": {
                 "maxLength": "200",
                 "minLength": "2",
-                "errorMessage":
-                    "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_max_message_addmember"
+                "errorMessage": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_max_message_addmember"
               },
               "validations": [
                 {
                   "type": "required",
                   "value": true,
-                  "message":
-                      "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_mandatory_message_addmember"
+                  "message": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_mandatory_message_addmember"
                 },
                 {
                   "type": "minLength",
                   "value": "2",
-                  "message":
-                      "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_max_message_addmember"
+                  "message": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_max_message_addmember"
                 },
                 {
                   "type": "maxLength",
                   "value": "200",
-                  "message":
-                      "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_max_message_addmember"
+                  "message": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_max_message_addmember"
                 }
               ],
               "errorMessage": "REGISTRATION_ADD_MEMBER_nameOfIndividual_ERROR",
               "isMultiSelect": false,
-              "required.message":
-                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_mandatory_message_addmember"
+              "required.message": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_mandatory_message_addmember"
             },
             {
               "type": "string",
               "enums": [
-                {"code": "DEFAULT", "name": "DEFAULT"},
+                {
+                  "code": "DEFAULT",
+                  "name": "DEFAULT"
+                },
                 {
                   "code": "UNIQUE_BENEFICIARY_ID",
                   "name": "UNIQUE_BENEFICIARY_ID"
                 }
               ],
-              "label":
-                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_identifiers_addmember",
+              "label": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_identifiers_addmember",
               "order": 3,
               "value": "",
               "format": "idPopulator",
@@ -4639,42 +4934,43 @@ final dynamic sampleSMCFlows = {
                 {
                   "type": "required",
                   "value": true,
-                  "message":
-                      "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_idpopulator_mandatory_message_addmember"
+                  "message": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_idpopulator_mandatory_message_addmember"
                 }
               ],
               "errorMessage": "REGISTRATION_ADD_MEMBER_identifiers_ERROR",
               "includeInForm": true,
               "isMultiSelect": false,
               "dropDownOptions": [
-                {"code": "DEFAULT", "name": "DEFAULT"},
+                {
+                  "code": "DEFAULT",
+                  "name": "DEFAULT"
+                },
                 {
                   "code": "UNIQUE_BENEFICIARY_ID",
                   "name": "UNIQUE_BENEFICIARY_ID"
                 },
-                {"code": "OTHER", "name": "OTHER"}
+                {
+                  "code": "OTHER",
+                  "name": "OTHER"
+                }
               ],
-              "required.message":
-                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_idpopulator_mandatory_message_addmember"
+              "required.message": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_idpopulator_mandatory_message_addmember"
             },
             {
               "type": "string",
-              "label":
-                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_dobPicker_addmember",
+              "label": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_dobPicker_addmember",
               "order": 4,
               "value": "",
               "format": "dob",
               "hidden": false,
               "isMdms": false,
-              "tooltip":
-                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_dobPicker_tooltip_addmember",
+              "tooltip": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_dobPicker_tooltip_addmember",
               "ageRange": {
                 "maxAge": 1800,
                 "minAge": 3,
                 "errorMessage": "AGE_VALIDATION_ADDMEMBER"
               },
-              "helpText":
-                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_dobPicker_helpText_addmember",
+              "helpText": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_dobPicker_helpText_addmember",
               "infoText": "",
               "readOnly": false,
               "required": true,
@@ -4688,8 +4984,7 @@ final dynamic sampleSMCFlows = {
                 {
                   "type": "required",
                   "value": true,
-                  "message":
-                      "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_dobPicker_mandatory_message_addmember"
+                  "message": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_dobPicker_mandatory_message_addmember"
                 },
                 {
                   "type": "minAge",
@@ -4704,17 +4999,21 @@ final dynamic sampleSMCFlows = {
               ],
               "errorMessage": "REGISTRATION_ADD_MEMBER_dobPicker_ERROR",
               "isMultiSelect": false,
-              "required.message":
-                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_dobPicker_mandatory_message_addmember"
+              "required.message": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_dobPicker_mandatory_message_addmember"
             },
             {
               "type": "string",
               "enums": [
-                {"code": "MALE", "name": "MALE"},
-                {"code": "FEMALE", "name": "FEMALE"}
+                {
+                  "code": "MALE",
+                  "name": "MALE"
+                },
+                {
+                  "code": "FEMALE",
+                  "name": "FEMALE"
+                }
               ],
-              "label":
-                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_gender_addmember",
+              "label": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_gender_addmember",
               "order": 5,
               "value": "",
               "format": "select",
@@ -4741,25 +5040,90 @@ final dynamic sampleSMCFlows = {
               "errorMessage": "REGISTRATION_ADD_MEMBER_gender_ERROR",
               "isMultiSelect": false,
               "dropDownOptions": [
-                {"code": "MALE", "name": "MALE"},
-                {"code": "FEMALE", "name": "FEMALE"}
+                {
+                  "code": "MALE",
+                  "name": "MALE"
+                },
+                {
+                  "code": "FEMALE",
+                  "name": "FEMALE"
+                }
               ],
               "required.message": "GENDER_MANDATORY_MESSAGE_ADDMEMBER"
             },
             {
-              "type": "string",
-              "label":
-                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_phone_addmember",
+              "type": "integer",
+              "label": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_height_addmember",
               "order": 6,
+              "value": "",
+              "format": "text",
+              "hidden": false,
+              "tooltip": "",
+              "helpText": "",
+              "infoText": "",
+              "readOnly": false,
+              "fieldName": "height",
+              "mandatory": true,
+              "deleteFlag": false,
+              "innerLabel": "",
+              "systemDate": false,
+              "validations": [
+                {
+                  "type": "required",
+                  "value": true,
+                  "message": "GENDER_MANDATORY_MESSAGE_HEIGHT_addmember"
+                },
+                {
+                  "type": "min",
+                  "value": true,
+                  "message": "APPONE_REGISTRATION_HOUSEDETAILS_label_height_Min_message_addmember"
+                },
+                {
+                  "type": "max",
+                  "value": true,
+                  "message": "APPONE_REGISTRATION_HOUSEDETAILS_label_height_Max_message_addmember"
+                }
+              ],
+              "errorMessage": "REGISTRATION_ADD_MEMBER_height_ERROR",
+              "isMultiSelect": false
+            },
+            {
+              "type": "integer",
+              "label": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_weight_addmember",
+              "order": 7,
+              "value": "",
+              "format": "text",
+              "hidden": false,
+              "tooltip": "",
+              "helpText": "",
+              "infoText": "",
+              "readOnly": false,
+              "fieldName": "weight",
+              "mandatory": true,
+              "deleteFlag": false,
+              "innerLabel": "",
+              "systemDate": false,
+              "validations": [
+                {
+                  "type": "required",
+                  "value": true,
+                  "message": "GENDER_MANDATORY_MESSAGE_WEIGHT_addmember"
+                }
+              ],
+              "errorMessage": "REGISTRATION_ADD_MEMBER_weight_ERROR",
+              "isMultiSelect": false
+            },
+            {
+              "type": "string",
+              "label": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_phone_addmember",
+              "order": 8,
               "value": "",
               "format": "mobileNumber",
               "hidden": false,
               "isMdms": false,
               "pattern": "^\\d+",
-              "tooltip":
-                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_phone_tooltip_addmember",
-              "helpText":
-                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_phone_helpText_addmember",
+              "tooltip": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_phone_tooltip_addmember",
+              "helpText": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_phone_helpText_addmember",
               "infoText": "",
               "readOnly": false,
               "fieldName": "phone",
@@ -4796,8 +5160,7 @@ final dynamic sampleSMCFlows = {
             },
             {
               "type": "string",
-              "label":
-                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_scanner_addmember",
+              "label": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_scanner_addmember",
               "order": 7,
               "value": "",
               "format": "scanner",
@@ -4827,10 +5190,8 @@ final dynamic sampleSMCFlows = {
               "includeInSummary": true
             }
           ],
-          "actionLabel":
-              "APPONE_REGISTRATION_BENEFICIARYDETAILS_ACTION_BUTTON_LABEL_addmember",
-          "description":
-              "APPONE_REGISTRATION_BENEFICIARYDETAILS_SCREEN_DESCRIPTION_addmember",
+          "actionLabel": "APPONE_REGISTRATION_BENEFICIARYDETAILS_ACTION_BUTTON_LABEL_addmember",
+          "description": "APPONE_REGISTRATION_BENEFICIARYDETAILS_SCREEN_DESCRIPTION_addmember",
           "showTabView": false,
           "submitCondition": null,
           "preventScreenCapture": false,
@@ -4854,7 +5215,9 @@ final dynamic sampleSMCFlows = {
             "onError": [
               {
                 "actionType": "SHOW_TOAST",
-                "properties": {"message": "REGISTRATION_ADD_MEMBER_MESSAGE"}
+                "properties": {
+                  "message": "REGISTRATION_ADD_MEMBER_MESSAGE"
+                }
               }
             ],
             "configName": "individualRegistration"
@@ -4869,7 +5232,10 @@ final dynamic sampleSMCFlows = {
               }
             }
           ],
-          "condition": {"type": "custom", "expression": "isEdit == true"}
+          "condition": {
+            "type": "custom",
+            "expression": "isEdit == true"
+          }
         },
         {
           "actions": [
@@ -4889,10 +5255,14 @@ final dynamic sampleSMCFlows = {
             },
             {
               "actionType": "CREATE_EVENT",
-              "properties": {"entity": "INDIVIDUAL, PROJECTBENEFICIARY, MEMBER"}
+              "properties": {
+                "entity": "INDIVIDUAL, PROJECTBENEFICIARY, MEMBER"
+              }
             }
           ],
-          "condition": {"expression": "DEFAULT"}
+          "condition": {
+            "expression": "DEFAULT"
+          }
         },
         {
           "actionType": "NAVIGATION",
@@ -4908,7 +5278,9 @@ final dynamic sampleSMCFlows = {
             "onError": [
               {
                 "actionType": "SHOW_TOAST",
-                "properties": {"message": "Navigation failed."}
+                "properties": {
+                  "message": "Navigation failed."
+                }
               }
             ],
             "navigationMode": "popUntilAndPush",
@@ -4921,7 +5293,10 @@ final dynamic sampleSMCFlows = {
       "initActions": [],
       "wrapperConfig": {
         "filters": [
-          {"field": "isHeadOfHousehold", "equals": true}
+          {
+            "field": "isHeadOfHousehold",
+            "equals": true
+          }
         ],
         "relations": [
           {
@@ -5022,7 +5397,10 @@ final dynamic sampleSMCFlows = {
               "onAction": [
                 {
                   "actionType": "NAVIGATION",
-                  "properties": {"name": "acknowledgement", "type": "screen"}
+                  "properties": {
+                    "name": "acknowledgement",
+                    "type": "screen"
+                  }
                 }
               ],
               "properties": {
@@ -5044,8 +5422,7 @@ final dynamic sampleSMCFlows = {
                 "data": [
                   {
                     "key": "selectedIndividualClientReferenceId",
-                    "value":
-                        "{{navigation.selectedIndividualClientReferenceId}}"
+                    "value": "{{navigation.selectedIndividualClientReferenceId}}"
                   },
                   {
                     "key": "selectedIndividualIdentifierId",
@@ -5057,8 +5434,7 @@ final dynamic sampleSMCFlows = {
                   },
                   {
                     "key": "ProjectBeneficiaryClientReferenceId",
-                    "value":
-                        "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                    "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                   },
                   {
                     "key": "selectedIndividualName",
@@ -5094,8 +5470,7 @@ final dynamic sampleSMCFlows = {
                 "data": [
                   {
                     "key": "selectedIndividualClientReferenceId",
-                    "value":
-                        "{{navigation.selectedIndividualClientReferenceId}}"
+                    "value": "{{navigation.selectedIndividualClientReferenceId}}"
                   },
                   {
                     "key": "selectedIndividualIdentifierId",
@@ -5107,8 +5482,7 @@ final dynamic sampleSMCFlows = {
                   },
                   {
                     "key": "ProjectBeneficiaryClientReferenceId",
-                    "value":
-                        "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                    "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                   },
                   {
                     "key": "selectedIndividualName",
@@ -5122,13 +5496,18 @@ final dynamic sampleSMCFlows = {
                     "key": "selectedIndividualAgeInMonths",
                     "value": "{{navigation.selectedIndividualAgeInMonths}}"
                   },
-                  {"key": "cycleIndex", "value": "{{navigation.cycleIndex}}"}
+                  {
+                    "key": "cycleIndex",
+                    "value": "{{navigation.cycleIndex}}"
+                  }
                 ],
                 "entity": "HFREFERRAL",
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {"message": "Failed to create HFReferral."}
+                    "properties": {
+                      "message": "Failed to create HFReferral."
+                    }
                   }
                 ]
               }
@@ -5139,8 +5518,7 @@ final dynamic sampleSMCFlows = {
                 "data": [
                   {
                     "key": "selectedIndividualClientReferenceId",
-                    "value":
-                        "{{navigation.selectedIndividualClientReferenceId}}"
+                    "value": "{{navigation.selectedIndividualClientReferenceId}}"
                   },
                   {
                     "key": "selectedIndividualIdentifierId",
@@ -5152,8 +5530,7 @@ final dynamic sampleSMCFlows = {
                   },
                   {
                     "key": "ProjectBeneficiaryClientReferenceId",
-                    "value":
-                        "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                    "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                   },
                   {
                     "key": "selectedIndividualName",
@@ -5167,7 +5544,10 @@ final dynamic sampleSMCFlows = {
                     "key": "selectedIndividualAgeInMonths",
                     "value": "{{navigation.selectedIndividualAgeInMonths}}"
                   },
-                  {"key": "cycleIndex", "value": "{{navigation.cycleIndex}}"}
+                  {
+                    "key": "cycleIndex",
+                    "value": "{{navigation.cycleIndex}}"
+                  }
                 ],
                 "name": "referralSuccess",
                 "type": "TEMPLATE",
@@ -5184,7 +5564,10 @@ final dynamic sampleSMCFlows = {
               }
             }
           ],
-          "navigateTo": {"name": "acknowledgement", "type": "screen"},
+          "navigateTo": {
+            "name": "acknowledgement",
+            "type": "screen"
+          },
           "properties": [
             {
               "type": "string",
@@ -5212,10 +5595,8 @@ final dynamic sampleSMCFlows = {
                   "message": "REFER_BENEFICIARY_ADMINISTRATIVE_UNIT_REQUIRED"
                 }
               ],
-              "errorMessage":
-                  "REGISTRATION_REFER_BENEFICIARY_administrativeArea_ERROR",
-              "required.message":
-                  "REFER_BENEFICIARY_ADMINISTRATIVE_UNIT_REQUIRED"
+              "errorMessage": "REGISTRATION_REFER_BENEFICIARY_administrativeArea_ERROR",
+              "required.message": "REFER_BENEFICIARY_ADMINISTRATIVE_UNIT_REQUIRED"
             },
             {
               "type": "string",
@@ -5246,7 +5627,10 @@ final dynamic sampleSMCFlows = {
               "errorMessage": "REGISTRATION_REFER_BENEFICIARY_referredBy_ERROR",
               "required.message": "REFER_BENEFICIARY_REFERRED_BY_REQUIRED",
               "autoFillCondition": [
-                {"value": "{{loggedInUserUuid}}", "expression": "true==true"}
+                {
+                  "value": "{{loggedInUserUuid}}",
+                  "expression": "true==true"
+                }
               ]
             },
             {
@@ -5276,17 +5660,18 @@ final dynamic sampleSMCFlows = {
                   "message": "REFER_BENEFICIARY_ADMINISTRATIVE_UNIT_REQUIRED"
                 }
               ],
-              "errorMessage":
-                  "REGISTRATION_REFER_BENEFICIARY_healthFacility_ERROR",
+              "errorMessage": "REGISTRATION_REFER_BENEFICIARY_healthFacility_ERROR",
               "includeInForm": true,
               "isMultiSelect": false,
-              "required.message":
-                  "REFER_BENEFICIARY_ADMINISTRATIVE_UNIT_REQUIRED"
+              "required.message": "REFER_BENEFICIARY_ADMINISTRATIVE_UNIT_REQUIRED"
             },
             {
               "type": "string",
               "enums": [
-                {"code": "FEVER", "name": "FEVER"}
+                {
+                  "code": "FEVER",
+                  "name": "FEVER"
+                }
               ],
               "label": "HFREFERRAL_REFERRAL_DETAILS_referralReason_LABEL",
               "order": 4,
@@ -5309,15 +5694,12 @@ final dynamic sampleSMCFlows = {
                 {
                   "type": "required",
                   "value": true,
-                  "message":
-                      "HFREFERRAL_REFERRAL_DETAILS_referralReason_REQUIRED_ERROR"
+                  "message": "HFREFERRAL_REFERRAL_DETAILS_referralReason_REQUIRED_ERROR"
                 }
               ],
-              "errorMessage":
-                  "REGISTRATION_REFER_BENEFICIARY_referralReason_ERROR",
+              "errorMessage": "REGISTRATION_REFER_BENEFICIARY_referralReason_ERROR",
               "isMultiSelect": false,
-              "required.message":
-                  "HFREFERRAL_REFERRAL_DETAILS_referralReason_REQUIRED_ERROR"
+              "required.message": "HFREFERRAL_REFERRAL_DETAILS_referralReason_REQUIRED_ERROR"
             }
           ],
           "actionLabel": "REFER_BENEFICIARY_SUBMIT_BUTTON",
@@ -5365,12 +5747,17 @@ final dynamic sampleSMCFlows = {
                 "key": "selectedIndividualAgeInMonths",
                 "value": "{{navigation.selectedIndividualAgeInMonths}}"
               },
-              {"key": "cycleIndex", "value": "{{fn:getCurrentCycleIndex()}}"}
+              {
+                "key": "cycleIndex",
+                "value": "{{fn:getCurrentCycleIndex()}}"
+              }
             ],
             "onError": [
               {
                 "actionType": "SHOW_TOAST",
-                "properties": {"message": "Failed to fetch config."}
+                "properties": {
+                  "message": "Failed to fetch config."
+                }
               }
             ],
             "configName": "referralBeneficaryCreate"
@@ -5408,13 +5795,18 @@ final dynamic sampleSMCFlows = {
                 "key": "selectedIndividualAgeInMonths",
                 "value": "{{navigation.selectedIndividualAgeInMonths}}"
               },
-              {"key": "cycleIndex", "value": "{{navigation.cycleIndex}}"}
+              {
+                "key": "cycleIndex",
+                "value": "{{navigation.cycleIndex}}"
+              }
             ],
             "entity": "HFREFERRAL",
             "onError": [
               {
                 "actionType": "SHOW_TOAST",
-                "properties": {"message": "Failed to create HFReferral."}
+                "properties": {
+                  "message": "Failed to create HFReferral."
+                }
               }
             ]
           }
@@ -5451,14 +5843,19 @@ final dynamic sampleSMCFlows = {
                 "key": "selectedIndividualAgeInMonths",
                 "value": "{{navigation.selectedIndividualAgeInMonths}}"
               },
-              {"key": "cycleIndex", "value": "{{navigation.cycleIndex}}"}
+              {
+                "key": "cycleIndex",
+                "value": "{{navigation.cycleIndex}}"
+              }
             ],
             "name": "referralSuccess",
             "type": "TEMPLATE",
             "onError": [
               {
                 "actionType": "SHOW_TOAST",
-                "properties": {"message": "Navigation failed."}
+                "properties": {
+                  "message": "Navigation failed."
+                }
               }
             ],
             "navigationMode": "popUntilAndPush",
@@ -5485,8 +5882,7 @@ final dynamic sampleSMCFlows = {
           "order": 4,
           "footer": [
             {
-              "label":
-                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_ACTION_BUTTON_LABEL_1",
+              "label": "APPONE_REGISTRATION_BENEFICIARYDETAILS_ACTION_BUTTON_LABEL_1",
               "format": "button",
               "onAction": [
                 {
@@ -5524,7 +5920,9 @@ final dynamic sampleSMCFlows = {
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {"message": "Failed to fetch config."}
+                        "properties": {
+                          "message": "Failed to fetch config."
+                        }
                       }
                     ],
                     "configName": "beneficiaryRegistration"
@@ -5535,7 +5933,10 @@ final dynamic sampleSMCFlows = {
                   "properties": {
                     "entity": "HouseholdModel, TaskModel",
                     "modify": [
-                      {"key": "TaskModel.status", "value": "NOT_ADMINISTERED"}
+                      {
+                        "key": "TaskModel.status",
+                        "value": "NOT_ADMINISTERED"
+                      }
                     ],
                     "onError": [
                       {
@@ -5553,8 +5954,7 @@ final dynamic sampleSMCFlows = {
                     "data": [
                       {
                         "key": "HouseholdClientReferenceId",
-                        "value":
-                            "{{contextData.entities.HouseholdModel.clientReferenceId}}"
+                        "value": "{{contextData.entities.HouseholdModel.clientReferenceId}}"
                       }
                     ],
                     "name": "householdOverview",
@@ -5562,7 +5962,9 @@ final dynamic sampleSMCFlows = {
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {"message": "Navigation failed."}
+                        "properties": {
+                          "message": "Navigation failed."
+                        }
                       }
                     ],
                     "navigationMode": "popUntilAndPush",
@@ -5583,7 +5985,9 @@ final dynamic sampleSMCFlows = {
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {"message": "Failed to fetch config."}
+                        "properties": {
+                          "message": "Failed to fetch config."
+                        }
                       }
                     ],
                     "configName": "beneficiaryRegistration"
@@ -5596,7 +6000,9 @@ final dynamic sampleSMCFlows = {
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {"message": "Failed to update household."}
+                        "properties": {
+                          "message": "Failed to update household."
+                        }
                       }
                     ]
                   }
@@ -5607,8 +6013,7 @@ final dynamic sampleSMCFlows = {
                     "data": [
                       {
                         "key": "HouseholdClientReferenceId",
-                        "value":
-                            "{{contextData.entities.HouseholdModel.clientReferenceId}}"
+                        "value": "{{contextData.entities.HouseholdModel.clientReferenceId}}"
                       }
                     ],
                     "name": "householdOverview",
@@ -5616,7 +6021,9 @@ final dynamic sampleSMCFlows = {
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {"message": "Navigation failed."}
+                        "properties": {
+                          "message": "Navigation failed."
+                        }
                       }
                     ],
                     "navigationMode": "popUntilAndPush",
@@ -5624,7 +6031,10 @@ final dynamic sampleSMCFlows = {
                   }
                 }
               ],
-              "condition": {"type": "custom", "expression": "isEdit==true"}
+              "condition": {
+                "type": "custom",
+                "expression": "isEdit==true"
+              }
             },
             {
               "actions": [
@@ -5634,7 +6044,9 @@ final dynamic sampleSMCFlows = {
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {"message": "Failed to fetch config."}
+                        "properties": {
+                          "message": "Failed to fetch config."
+                        }
                       }
                     ],
                     "configName": "beneficiaryRegistration"
@@ -5643,12 +6055,13 @@ final dynamic sampleSMCFlows = {
                 {
                   "actionType": "CREATE_EVENT",
                   "properties": {
-                    "entity":
-                        "HOUSEHOLD, INDIVIDUAL, PROJECTBENEFICIARY, MEMBER",
+                    "entity": "HOUSEHOLD, INDIVIDUAL, PROJECTBENEFICIARY, MEMBER",
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {"message": "Failed to create household."}
+                        "properties": {
+                          "message": "Failed to create household."
+                        }
                       }
                     ]
                   }
@@ -5659,8 +6072,7 @@ final dynamic sampleSMCFlows = {
                     "data": [
                       {
                         "key": "HouseholdClientReferenceId",
-                        "value":
-                            "{{contextData.entities.HouseholdModel.clientReferenceId}}"
+                        "value": "{{contextData.entities.HouseholdModel.clientReferenceId}}"
                       }
                     ],
                     "name": "householdOverview",
@@ -5668,7 +6080,9 @@ final dynamic sampleSMCFlows = {
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {"message": "Navigation failed."}
+                        "properties": {
+                          "message": "Navigation failed."
+                        }
                       }
                     ],
                     "navigationMode": "popUntilAndPush",
@@ -5676,7 +6090,9 @@ final dynamic sampleSMCFlows = {
                   }
                 }
               ],
-              "condition": {"expression": "DEFAULT"}
+              "condition": {
+                "expression": "DEFAULT"
+              }
             }
           ],
           "navigateTo": {
@@ -5692,16 +6108,14 @@ final dynamic sampleSMCFlows = {
           "properties": [
             {
               "type": "string",
-              "label":
-                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual",
+              "label": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual",
               "order": 1,
               "value": "",
               "format": "text",
               "hidden": false,
               "isMdms": false,
               "tooltip": "",
-              "helpText":
-                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_helpText",
+              "helpText": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_helpText",
               "infoText": "",
               "readOnly": false,
               "required": true,
@@ -5714,38 +6128,32 @@ final dynamic sampleSMCFlows = {
               "lengthRange": {
                 "maxLength": "200",
                 "minLength": "2",
-                "errorMessage":
-                    "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_max_message"
+                "errorMessage": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_max_message"
               },
               "validations": [
                 {
                   "type": "required",
                   "value": true,
-                  "message":
-                      "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_mandatory_message"
+                  "message": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_mandatory_message"
                 },
                 {
                   "type": "minLength",
                   "value": "2",
-                  "message":
-                      "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_max_message"
+                  "message": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_max_message"
                 },
                 {
                   "type": "maxLength",
                   "value": "200",
-                  "message":
-                      "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_max_message"
+                  "message": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_max_message"
                 }
               ],
               "errorMessage": "REGISTRATION_HOUSEHOLD_nameOfIndividual_ERROR",
               "isMultiSelect": false,
-              "required.message":
-                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_mandatory_message"
+              "required.message": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_mandatory_message"
             },
             {
               "type": "boolean",
-              "label":
-                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_isHeadOfFamily",
+              "label": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_isHeadOfFamily",
               "order": 3,
               "value": "",
               "format": "checkbox",
@@ -5767,26 +6175,26 @@ final dynamic sampleSMCFlows = {
                 {
                   "type": "required",
                   "value": true,
-                  "message":
-                      "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_isHeadOfFamily_mandatory_message"
+                  "message": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_isHeadOfFamily_mandatory_message"
                 }
               ],
               "errorMessage": "REGISTRATION_HOUSEHOLD_isHeadOfFamily_ERROR",
               "isMultiSelect": false,
-              "required.message":
-                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_isHeadOfFamily_mandatory_message"
+              "required.message": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_isHeadOfFamily_mandatory_message"
             },
             {
               "type": "string",
               "enums": [
-                {"code": "DEFAULT", "name": "DEFAULT"},
+                {
+                  "code": "DEFAULT",
+                  "name": "DEFAULT"
+                },
                 {
                   "code": "UNIQUE_BENEFICIARY_ID",
                   "name": "UNIQUE_BENEFICIARY_ID"
                 }
               ],
-              "label":
-                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_identifiers",
+              "label": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_identifiers",
               "order": 4,
               "value": "",
               "format": "idPopulator",
@@ -5807,14 +6215,12 @@ final dynamic sampleSMCFlows = {
                 {
                   "type": "required",
                   "value": true,
-                  "message":
-                      "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_idpopulator_mandatory_message"
+                  "message": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_idpopulator_mandatory_message"
                 }
               ],
               "errorMessage": "REGISTRATION_HOUSEHOLD_identifiers_ERROR",
               "isMultiSelect": false,
-              "required.message":
-                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_idpopulator_mandatory_message"
+              "required.message": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_idpopulator_mandatory_message"
             },
             {
               "type": "string",
@@ -5824,15 +6230,13 @@ final dynamic sampleSMCFlows = {
               "format": "dob",
               "hidden": false,
               "isMdms": false,
-              "tooltip":
-                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_dobPicker_tooltip",
+              "tooltip": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_dobPicker_tooltip",
               "ageRange": {
                 "maxAge": 1800,
                 "minAge": 3,
                 "errorMessage": "AGE_VALIDATION"
               },
-              "helpText":
-                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_dobPicker_helpText",
+              "helpText": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_dobPicker_helpText",
               "infoText": "",
               "readOnly": false,
               "required": true,
@@ -5846,22 +6250,34 @@ final dynamic sampleSMCFlows = {
                 {
                   "type": "required",
                   "value": true,
-                  "message":
-                      "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_dobPicker_mandatory_message"
+                  "message": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_dobPicker_mandatory_message"
                 },
-                {"type": "minAge", "value": 3, "message": "AGE_VALIDATION"},
-                {"type": "maxAge", "value": 1800, "message": "AGE_VALIDATION"}
+                {
+                  "type": "minAge",
+                  "value": 3,
+                  "message": "AGE_VALIDATION"
+                },
+                {
+                  "type": "maxAge",
+                  "value": 1800,
+                  "message": "AGE_VALIDATION"
+                }
               ],
               "errorMessage": "REGISTRATION_HOUSEHOLD_dobPicker_ERROR",
               "isMultiSelect": false,
-              "required.message":
-                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_dobPicker_mandatory_message"
+              "required.message": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_dobPicker_mandatory_message"
             },
             {
               "type": "string",
               "enums": [
-                {"code": "MALE", "name": "MALE"},
-                {"code": "FEMALE", "name": "FEMALE"}
+                {
+                  "code": "MALE",
+                  "name": "MALE"
+                },
+                {
+                  "code": "FEMALE",
+                  "name": "FEMALE"
+                }
               ],
               "label": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_gender",
               "order": 6,
@@ -5892,18 +6308,78 @@ final dynamic sampleSMCFlows = {
               "required.message": "GENDER_MANDATORY_MESSAGE"
             },
             {
+              "type": "integer",
+              "label": "APPONE_REGISTRATION_HOUSEDETAILS_label_height",
+              "order": 7,
+              "value": "",
+              "format": "text",
+              "hidden": false,
+              "tooltip": "",
+              "helpText": "",
+              "infoText": "",
+              "readOnly": false,
+              "fieldName": "height",
+              "mandatory": true,
+              "deleteFlag": false,
+              "innerLabel": "",
+              "systemDate": false,
+              "validations": [
+                {
+                  "type": "required",
+                  "value": true,
+                  "message": "APPONE_REGISTRATION_HOUSEDETAILS_label_height_IS_MANDATORY"
+                },
+                {
+                  "type": "min",
+                  "value": true,
+                  "message": "APPONE_REGISTRATION_HOUSEDETAILS_label_height_Min_message"
+                },
+                {
+                  "type": "max",
+                  "value": true,
+                  "message": "APPONE_REGISTRATION_HOUSEDETAILS_label_height_Max_message"
+                }
+              ],
+              "errorMessage": "REGISTRATION_HOUSEHOLD_height_ERROR",
+              "isMultiSelect": false
+            },
+            {
+              "type": "integer",
+              "label": "APPONE_REGISTRATION_HOUSEDETAILS_label_weight",
+              "order": 8,
+              "value": "",
+              "format": "text",
+              "hidden": false,
+              "tooltip": "",
+              "helpText": "",
+              "infoText": "",
+              "readOnly": false,
+              "fieldName": "weight",
+              "mandatory": true,
+              "deleteFlag": false,
+              "innerLabel": "",
+              "systemDate": false,
+              "validations": [
+                {
+                  "type": "required",
+                  "value": true,
+                  "message": "APPONE_REGISTRATION_HOUSEDETAILS_label_weight_IS_MANDATORY"
+                }
+              ],
+              "errorMessage": "REGISTRATION_HOUSEHOLD_weight_ERROR",
+              "isMultiSelect": false
+            },
+            {
               "type": "string",
               "label": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_phone",
-              "order": 7,
+              "order": 9,
               "value": "",
               "format": "mobileNumber",
               "hidden": false,
               "isMdms": false,
               "pattern": "^\\d+",
-              "tooltip":
-                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_phone_tooltip",
-              "helpText":
-                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_phone_helpText",
+              "tooltip": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_phone_tooltip",
+              "helpText": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_phone_helpText",
               "infoText": "",
               "readOnly": false,
               "fieldName": "phone",
@@ -5941,7 +6417,7 @@ final dynamic sampleSMCFlows = {
             {
               "type": "string",
               "label": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_scanner",
-              "order": 8,
+              "order": 10,
               "value": "",
               "format": "scanner",
               "hidden": false,
@@ -5970,10 +6446,8 @@ final dynamic sampleSMCFlows = {
               "includeInSummary": true
             }
           ],
-          "actionLabel":
-              "APPONE_REGISTRATION_BENEFICIARYDETAILS_ACTION_BUTTON_LABEL_1",
-          "description":
-              "APPONE_REGISTRATION_BENEFICIARYDETAILS_SCREEN_DESCRIPTION",
+          "actionLabel": "APPONE_REGISTRATION_BENEFICIARYDETAILS_ACTION_BUTTON_LABEL_1",
+          "description": "APPONE_REGISTRATION_BENEFICIARYDETAILS_SCREEN_DESCRIPTION",
           "showTabView": false,
           "submitCondition": null,
           "preventScreenCapture": false,
@@ -5988,13 +6462,15 @@ final dynamic sampleSMCFlows = {
           "order": 3,
           "footer": [
             {
-              "label":
-                  "APPONE_REGISTRATION_HOUSEHOLDDETAILS_ACTION_BUTTON_LABEL_1",
+              "label": "APPONE_REGISTRATION_HOUSEHOLDDETAILS_ACTION_BUTTON_LABEL_1",
               "format": "button",
               "onAction": [
                 {
                   "actionType": "NAVIGATION",
-                  "properties": {"name": "beneficiaryDetails", "type": "form"}
+                  "properties": {
+                    "name": "beneficiaryDetails",
+                    "type": "form"
+                  }
                 }
               ],
               "properties": {
@@ -6031,7 +6507,10 @@ final dynamic sampleSMCFlows = {
                   "properties": {
                     "entity": "HouseholdModel, TaskModel",
                     "modify": [
-                      {"key": "TaskModel.status", "value": "NOT_ADMINISTERED"}
+                      {
+                        "key": "TaskModel.status",
+                        "value": "NOT_ADMINISTERED"
+                      }
                     ],
                     "onError": [
                       {
@@ -6049,8 +6528,7 @@ final dynamic sampleSMCFlows = {
                     "data": [
                       {
                         "key": "HouseholdClientReferenceId",
-                        "value":
-                            "{{contextData.entities.HouseholdModel.clientReferenceId}}"
+                        "value": "{{contextData.entities.HouseholdModel.clientReferenceId}}"
                       }
                     ],
                     "name": "householdOverview",
@@ -6058,7 +6536,9 @@ final dynamic sampleSMCFlows = {
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {"message": "Navigation failed."}
+                        "properties": {
+                          "message": "Navigation failed."
+                        }
                       }
                     ],
                     "navigationMode": "popUntilAndPush",
@@ -6079,7 +6559,9 @@ final dynamic sampleSMCFlows = {
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {"message": "Failed to fetch config."}
+                        "properties": {
+                          "message": "Failed to fetch config."
+                        }
                       }
                     ],
                     "configName": "beneficiaryRegistration"
@@ -6092,7 +6574,9 @@ final dynamic sampleSMCFlows = {
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {"message": "Failed to update household."}
+                        "properties": {
+                          "message": "Failed to update household."
+                        }
                       }
                     ]
                   }
@@ -6103,8 +6587,7 @@ final dynamic sampleSMCFlows = {
                     "data": [
                       {
                         "key": "HouseholdClientReferenceId",
-                        "value":
-                            "{{contextData.entities.HouseholdModel.clientReferenceId}}"
+                        "value": "{{contextData.entities.HouseholdModel.clientReferenceId}}"
                       }
                     ],
                     "name": "householdOverview",
@@ -6112,7 +6595,9 @@ final dynamic sampleSMCFlows = {
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {"message": "Navigation failed."}
+                        "properties": {
+                          "message": "Navigation failed."
+                        }
                       }
                     ],
                     "navigationMode": "popUntilAndPush",
@@ -6120,7 +6605,10 @@ final dynamic sampleSMCFlows = {
                   }
                 }
               ],
-              "condition": {"type": "custom", "expression": "isEdit==true"}
+              "condition": {
+                "type": "custom",
+                "expression": "isEdit==true"
+              }
             },
             {
               "actions": [
@@ -6130,7 +6618,9 @@ final dynamic sampleSMCFlows = {
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {"message": "Failed to fetch config."}
+                        "properties": {
+                          "message": "Failed to fetch config."
+                        }
                       }
                     ],
                     "configName": "beneficiaryRegistration"
@@ -6139,12 +6629,13 @@ final dynamic sampleSMCFlows = {
                 {
                   "actionType": "CREATE_EVENT",
                   "properties": {
-                    "entity":
-                        "HOUSEHOLD, INDIVIDUAL, PROJECTBENEFICIARY, MEMBER",
+                    "entity": "HOUSEHOLD, INDIVIDUAL, PROJECTBENEFICIARY, MEMBER",
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {"message": "Failed to create household."}
+                        "properties": {
+                          "message": "Failed to create household."
+                        }
                       }
                     ]
                   }
@@ -6155,8 +6646,7 @@ final dynamic sampleSMCFlows = {
                     "data": [
                       {
                         "key": "HouseholdClientReferenceId",
-                        "value":
-                            "{{contextData.entities.HouseholdModel.clientReferenceId}}"
+                        "value": "{{contextData.entities.HouseholdModel.clientReferenceId}}"
                       }
                     ],
                     "name": "householdOverview",
@@ -6164,7 +6654,9 @@ final dynamic sampleSMCFlows = {
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {"message": "Navigation failed."}
+                        "properties": {
+                          "message": "Navigation failed."
+                        }
                       }
                     ],
                     "navigationMode": "popUntilAndPush",
@@ -6172,15 +6664,19 @@ final dynamic sampleSMCFlows = {
                   }
                 }
               ],
-              "condition": {"expression": "DEFAULT"}
+              "condition": {
+                "expression": "DEFAULT"
+              }
             }
           ],
-          "navigateTo": {"name": "beneficiaryDetails", "type": "form"},
+          "navigateTo": {
+            "name": "beneficiaryDetails",
+            "type": "form"
+          },
           "properties": [
             {
               "type": "string",
-              "label":
-                  "APPONE_REGISTRATION_HOUSEHOLDDETAILS_label_dateOfRegistration",
+              "label": "APPONE_REGISTRATION_HOUSEHOLDDETAILS_label_dateOfRegistration",
               "order": 1,
               "value": "",
               "format": "date",
@@ -6201,19 +6697,16 @@ final dynamic sampleSMCFlows = {
                 {
                   "type": "required",
                   "value": true,
-                  "message":
-                      "APPONE_REGISTRATION_HOUSEHOLDDETAILS_label_dateOfRegistration_mandatory_message"
+                  "message": "APPONE_REGISTRATION_HOUSEHOLDDETAILS_label_dateOfRegistration_mandatory_message"
                 }
               ],
               "errorMessage": "REGISTRATION_HOUSEHOLD_dateOfRegistration_ERROR",
               "isMultiSelect": false,
-              "required.message":
-                  "APPONE_REGISTRATION_HOUSEHOLDDETAILS_label_dateOfRegistration_mandatory_message"
+              "required.message": "APPONE_REGISTRATION_HOUSEHOLDDETAILS_label_dateOfRegistration_mandatory_message"
             },
             {
               "type": "integer",
-              "label":
-                  "APPONE_REGISTRATION_HOUSEHOLDDETAILS_label_childrenCount",
+              "label": "APPONE_REGISTRATION_HOUSEHOLDDETAILS_label_childrenCount",
               "order": 2,
               "value": "0",
               "format": "numeric",
@@ -6235,8 +6728,7 @@ final dynamic sampleSMCFlows = {
             },
             {
               "type": "integer",
-              "label":
-                  "APPONE_REGISTRATION_HOUSEHOLDDETAILS_label_pregnantWomenCount",
+              "label": "APPONE_REGISTRATION_HOUSEHOLDDETAILS_label_pregnantWomenCount",
               "order": 3,
               "value": "0",
               "format": "numeric",
@@ -6263,8 +6755,7 @@ final dynamic sampleSMCFlows = {
               "range": {
                 "max": "10",
                 "min": "1",
-                "errorMessage":
-                    "APPONE_REGISTRATION_HOUSEHOLDDETAILS_label_memberCount_max_message"
+                "errorMessage": "APPONE_REGISTRATION_HOUSEHOLDDETAILS_label_memberCount_max_message"
               },
               "value": "1",
               "format": "numeric",
@@ -6285,36 +6776,32 @@ final dynamic sampleSMCFlows = {
                 {
                   "type": "required",
                   "value": true,
-                  "message":
-                      "APPONE_REGISTRATION_HOUSEHOLDDETAILS_label_memberCount_mandatory_message"
+                  "message": "APPONE_REGISTRATION_HOUSEHOLDDETAILS_label_memberCount_mandatory_message"
                 },
                 {
                   "type": "min",
                   "value": "1",
-                  "message":
-                      "APPONE_REGISTRATION_HOUSEHOLDDETAILS_label_memberCount_max_message"
+                  "message": "APPONE_REGISTRATION_HOUSEHOLDDETAILS_label_memberCount_max_message"
                 },
                 {
                   "type": "max",
                   "value": "10",
-                  "message":
-                      "APPONE_REGISTRATION_HOUSEHOLDDETAILS_label_memberCount_max_message"
+                  "message": "APPONE_REGISTRATION_HOUSEHOLDDETAILS_label_memberCount_max_message"
                 }
               ],
               "errorMessage": "REGISTRATION_HOUSEHOLD_memberCount_ERROR",
               "isMultiSelect": false,
-              "required.message":
-                  "APPONE_REGISTRATION_HOUSEHOLDDETAILS_label_memberCount_mandatory_message"
+              "required.message": "APPONE_REGISTRATION_HOUSEHOLDDETAILS_label_memberCount_mandatory_message"
             }
           ],
-          "actionLabel":
-              "APPONE_REGISTRATION_HOUSEHOLDDETAILS_ACTION_BUTTON_LABEL_1",
-          "description":
-              "APPONE_REGISTRATION_HOUSEHOLDDETAILS_SCREEN_DESCRIPTION",
+          "actionLabel": "APPONE_REGISTRATION_HOUSEHOLDDETAILS_ACTION_BUTTON_LABEL_1",
+          "description": "APPONE_REGISTRATION_HOUSEHOLDDETAILS_SCREEN_DESCRIPTION",
           "showTabView": false,
           "submitCondition": {
             "expression": [
-              {"condition": "isEdit == true"}
+              {
+                "condition": "isEdit == true"
+              }
             ]
           },
           "preventScreenCapture": false
@@ -6328,13 +6815,15 @@ final dynamic sampleSMCFlows = {
           "order": 1,
           "footer": [
             {
-              "label":
-                  "APPONE_REGISTRATION_BENEFICIARY_LOCATION_ACTION_BUTTON_LABEL_1",
+              "label": "APPONE_REGISTRATION_BENEFICIARY_LOCATION_ACTION_BUTTON_LABEL_1",
               "format": "button",
               "onAction": [
                 {
                   "actionType": "NAVIGATION",
-                  "properties": {"name": "householdDetails", "type": "form"}
+                  "properties": {
+                    "name": "householdDetails",
+                    "type": "form"
+                  }
                 }
               ],
               "properties": {
@@ -6371,7 +6860,10 @@ final dynamic sampleSMCFlows = {
                   "properties": {
                     "entity": "HouseholdModel, TaskModel",
                     "modify": [
-                      {"key": "TaskModel.status", "value": "NOT_ADMINISTERED"}
+                      {
+                        "key": "TaskModel.status",
+                        "value": "NOT_ADMINISTERED"
+                      }
                     ],
                     "onError": [
                       {
@@ -6389,8 +6881,7 @@ final dynamic sampleSMCFlows = {
                     "data": [
                       {
                         "key": "HouseholdClientReferenceId",
-                        "value":
-                            "{{contextData.entities.HouseholdModel.clientReferenceId}}"
+                        "value": "{{contextData.entities.HouseholdModel.clientReferenceId}}"
                       }
                     ],
                     "name": "householdOverview",
@@ -6398,7 +6889,9 @@ final dynamic sampleSMCFlows = {
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {"message": "Navigation failed."}
+                        "properties": {
+                          "message": "Navigation failed."
+                        }
                       }
                     ],
                     "navigationMode": "popUntilAndPush",
@@ -6419,7 +6912,9 @@ final dynamic sampleSMCFlows = {
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {"message": "Failed to fetch config."}
+                        "properties": {
+                          "message": "Failed to fetch config."
+                        }
                       }
                     ],
                     "configName": "beneficiaryRegistration"
@@ -6432,7 +6927,9 @@ final dynamic sampleSMCFlows = {
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {"message": "Failed to update household."}
+                        "properties": {
+                          "message": "Failed to update household."
+                        }
                       }
                     ]
                   }
@@ -6443,8 +6940,7 @@ final dynamic sampleSMCFlows = {
                     "data": [
                       {
                         "key": "HouseholdClientReferenceId",
-                        "value":
-                            "{{contextData.entities.HouseholdModel.clientReferenceId}}"
+                        "value": "{{contextData.entities.HouseholdModel.clientReferenceId}}"
                       }
                     ],
                     "name": "householdOverview",
@@ -6452,7 +6948,9 @@ final dynamic sampleSMCFlows = {
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {"message": "Navigation failed."}
+                        "properties": {
+                          "message": "Navigation failed."
+                        }
                       }
                     ],
                     "navigationMode": "popUntilAndPush",
@@ -6460,7 +6958,10 @@ final dynamic sampleSMCFlows = {
                   }
                 }
               ],
-              "condition": {"type": "custom", "expression": "isEdit==true"}
+              "condition": {
+                "type": "custom",
+                "expression": "isEdit==true"
+              }
             },
             {
               "actions": [
@@ -6470,7 +6971,9 @@ final dynamic sampleSMCFlows = {
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {"message": "Failed to fetch config."}
+                        "properties": {
+                          "message": "Failed to fetch config."
+                        }
                       }
                     ],
                     "configName": "beneficiaryRegistration"
@@ -6479,12 +6982,13 @@ final dynamic sampleSMCFlows = {
                 {
                   "actionType": "CREATE_EVENT",
                   "properties": {
-                    "entity":
-                        "HOUSEHOLD, INDIVIDUAL, PROJECTBENEFICIARY, MEMBER",
+                    "entity": "HOUSEHOLD, INDIVIDUAL, PROJECTBENEFICIARY, MEMBER",
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {"message": "Failed to create household."}
+                        "properties": {
+                          "message": "Failed to create household."
+                        }
                       }
                     ]
                   }
@@ -6495,8 +6999,7 @@ final dynamic sampleSMCFlows = {
                     "data": [
                       {
                         "key": "HouseholdClientReferenceId",
-                        "value":
-                            "{{contextData.entities.HouseholdModel.clientReferenceId}}"
+                        "value": "{{contextData.entities.HouseholdModel.clientReferenceId}}"
                       }
                     ],
                     "name": "householdOverview",
@@ -6504,7 +7007,9 @@ final dynamic sampleSMCFlows = {
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {"message": "Navigation failed."}
+                        "properties": {
+                          "message": "Navigation failed."
+                        }
                       }
                     ],
                     "navigationMode": "popUntilAndPush",
@@ -6512,23 +7017,26 @@ final dynamic sampleSMCFlows = {
                   }
                 }
               ],
-              "condition": {"expression": "DEFAULT"}
+              "condition": {
+                "expression": "DEFAULT"
+              }
             }
           ],
-          "navigateTo": {"name": "householdDetails", "type": "form"},
+          "navigateTo": {
+            "name": "householdDetails",
+            "type": "form"
+          },
           "properties": [
             {
               "type": "string",
-              "label":
-                  "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_administrativeArea",
+              "label": "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_administrativeArea",
               "order": 1,
               "value": "",
               "format": "locality",
               "hidden": false,
               "isMdms": false,
               "tooltip": "",
-              "helpText":
-                  "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_administrativeArea_helpText",
+              "helpText": "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_administrativeArea_helpText",
               "infoText": "",
               "readOnly": false,
               "required": true,
@@ -6542,14 +7050,12 @@ final dynamic sampleSMCFlows = {
                 {
                   "type": "required",
                   "value": true,
-                  "message":
-                      "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_administrativeArea_mandatory_message"
+                  "message": "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_administrativeArea_mandatory_message"
                 }
               ],
               "errorMessage": "REGISTRATION_HOUSEHOLD_administrativeArea_ERROR",
               "isMultiSelect": false,
-              "required.message":
-                  "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_administrativeArea_mandatory_message"
+              "required.message": "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_administrativeArea_mandatory_message"
             },
             {
               "type": "string",
@@ -6560,8 +7066,7 @@ final dynamic sampleSMCFlows = {
               "hidden": false,
               "isMdms": false,
               "tooltip": "",
-              "helpText":
-                  "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_latlong_helpText",
+              "helpText": "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_latlong_helpText",
               "infoText": "",
               "readOnly": false,
               "required": true,
@@ -6575,27 +7080,23 @@ final dynamic sampleSMCFlows = {
                 {
                   "type": "required",
                   "value": true,
-                  "message":
-                      "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_latlong_mandatory_message"
+                  "message": "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_latlong_mandatory_message"
                 }
               ],
               "errorMessage": "REGISTRATION_HOUSEHOLD_latLng_ERROR",
               "isMultiSelect": false,
-              "required.message":
-                  "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_latlong_mandatory_message"
+              "required.message": "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_latlong_mandatory_message"
             },
             {
               "type": "string",
-              "label":
-                  "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_addressLine1",
+              "label": "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_addressLine1",
               "order": 3,
               "value": "",
               "format": "text",
               "hidden": true,
               "isMdms": false,
               "tooltip": "",
-              "helpText":
-                  "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_addressLine1_helpText",
+              "helpText": "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_addressLine1_helpText",
               "infoText": "",
               "readOnly": false,
               "fieldName": "addressLine1",
@@ -6606,15 +7107,13 @@ final dynamic sampleSMCFlows = {
               "systemDate": false,
               "lengthRange": {
                 "minLength": "2",
-                "errorMessage":
-                    "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_addressLine1_min_message"
+                "errorMessage": "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_addressLine1_min_message"
               },
               "validations": [
                 {
                   "type": "minLength",
                   "value": "2",
-                  "message":
-                      "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_addressLine1_min_message"
+                  "message": "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_addressLine1_min_message"
                 }
               ],
               "errorMessage": "REGISTRATION_HOUSEHOLD_addressLine1_ERROR",
@@ -6622,16 +7121,14 @@ final dynamic sampleSMCFlows = {
             },
             {
               "type": "string",
-              "label":
-                  "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_addressLine2",
+              "label": "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_addressLine2",
               "order": 4,
               "value": "",
               "format": "text",
               "hidden": true,
               "isMdms": false,
               "tooltip": "",
-              "helpText":
-                  "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_addressLine2_helpText",
+              "helpText": "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_addressLine2_helpText",
               "infoText": "",
               "readOnly": false,
               "fieldName": "addressLine2",
@@ -6642,15 +7139,13 @@ final dynamic sampleSMCFlows = {
               "systemDate": false,
               "lengthRange": {
                 "minLength": "2",
-                "errorMessage":
-                    "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_addressLine2_min_message"
+                "errorMessage": "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_addressLine2_min_message"
               },
               "validations": [
                 {
                   "type": "minLength",
                   "value": "2",
-                  "message":
-                      "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_addressLine2_min_message"
+                  "message": "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_addressLine2_min_message"
                 }
               ],
               "errorMessage": "REGISTRATION_HOUSEHOLD_addressLine2_ERROR",
@@ -6665,8 +7160,7 @@ final dynamic sampleSMCFlows = {
               "hidden": true,
               "isMdms": false,
               "tooltip": "",
-              "helpText":
-                  "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_landmark_helpText",
+              "helpText": "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_landmark_helpText",
               "infoText": "",
               "readOnly": false,
               "fieldName": "landmark",
@@ -6677,15 +7171,13 @@ final dynamic sampleSMCFlows = {
               "systemDate": false,
               "lengthRange": {
                 "minLength": "2",
-                "errorMessage":
-                    "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_landmark_min_message"
+                "errorMessage": "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_landmark_min_message"
               },
               "validations": [
                 {
                   "type": "minLength",
                   "value": "2",
-                  "message":
-                      "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_landmark_min_message"
+                  "message": "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_landmark_min_message"
                 }
               ],
               "errorMessage": "REGISTRATION_HOUSEHOLD_landmark_ERROR",
@@ -6701,8 +7193,7 @@ final dynamic sampleSMCFlows = {
               "isMdms": false,
               "pattern": "^\\d+",
               "tooltip": "",
-              "helpText":
-                  "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_pincode_helpText",
+              "helpText": "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_pincode_helpText",
               "infoText": "",
               "readOnly": false,
               "fieldName": "pincode",
@@ -6724,15 +7215,20 @@ final dynamic sampleSMCFlows = {
             {
               "type": "string",
               "enums": [
-                {"code": "PERMANENT", "name": "BENEFICIARYLOCATION_PERMANENT"},
+                {
+                  "code": "PERMANENT",
+                  "name": "BENEFICIARYLOCATION_PERMANENT"
+                },
                 {
                   "code": "CORRESPONDENCE",
                   "name": "BENEFICIARYLOCATION_CORRESPONDENCE"
                 },
-                {"code": "OTHER", "name": "BENEFICIARYLOCATION_OTHER"}
+                {
+                  "code": "OTHER",
+                  "name": "BENEFICIARYLOCATION_OTHER"
+                }
               ],
-              "label":
-                  "APPONE_REGISTRATION_BENEFICIARY_LOCATION_label_typeOfAddress",
+              "label": "APPONE_REGISTRATION_BENEFICIARY_LOCATION_label_typeOfAddress",
               "order": 7,
               "value": "PERMANENT",
               "format": "dropdown",
@@ -6753,20 +7249,24 @@ final dynamic sampleSMCFlows = {
               "includeInForm": true,
               "isMultiSelect": false,
               "dropDownOptions": [
-                {"code": "PERMANENT", "name": "BENEFICIARYLOCATION_PERMANENT"},
+                {
+                  "code": "PERMANENT",
+                  "name": "BENEFICIARYLOCATION_PERMANENT"
+                },
                 {
                   "code": "CORRESPONDENCE",
                   "name": "BENEFICIARYLOCATION_CORRESPONDENCE"
                 },
-                {"code": "OTHER", "name": "BENEFICIARYLOCATION_OTHER"}
+                {
+                  "code": "OTHER",
+                  "name": "BENEFICIARYLOCATION_OTHER"
+                }
               ],
               "includeInSummary": false
             }
           ],
-          "actionLabel":
-              "APPONE_REGISTRATION_BENEFICIARY_LOCATION_ACTION_BUTTON_LABEL_1",
-          "description":
-              "APPONE_REGISTRATION_BENEFICIARY_LOCATION_SCREEN_DESCRIPTION",
+          "actionLabel": "APPONE_REGISTRATION_BENEFICIARY_LOCATION_ACTION_BUTTON_LABEL_1",
+          "description": "APPONE_REGISTRATION_BENEFICIARY_LOCATION_SCREEN_DESCRIPTION",
           "showTabView": false,
           "submitCondition": null,
           "preventScreenCapture": false
@@ -6785,7 +7285,9 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {"message": "REGISTRATION_HOUSEHOLD_MESSAGE"}
+                    "properties": {
+                      "message": "REGISTRATION_HOUSEHOLD_MESSAGE"
+                    }
                   }
                 ],
                 "configName": "beneficiaryRegistration"
@@ -6796,7 +7298,10 @@ final dynamic sampleSMCFlows = {
               "properties": {
                 "entity": "HouseholdModel, TaskModel",
                 "modify": [
-                  {"key": "TaskModel.status", "value": "NOT_ADMINISTERED"}
+                  {
+                    "key": "TaskModel.status",
+                    "value": "NOT_ADMINISTERED"
+                  }
                 ],
                 "onError": [
                   {
@@ -6814,8 +7319,7 @@ final dynamic sampleSMCFlows = {
                 "data": [
                   {
                     "key": "HouseholdClientReferenceId",
-                    "value":
-                        "{{contextData.entities.HouseholdModel.clientReferenceId}}"
+                    "value": "{{contextData.entities.HouseholdModel.clientReferenceId}}"
                   }
                 ],
                 "name": "householdOverview",
@@ -6823,7 +7327,9 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {"message": "Navigation failed."}
+                    "properties": {
+                      "message": "Navigation failed."
+                    }
                   }
                 ],
                 "navigationMode": "popUntilAndPush",
@@ -6843,7 +7349,9 @@ final dynamic sampleSMCFlows = {
             "onError": [
               {
                 "actionType": "SHOW_TOAST",
-                "properties": {"message": "Failed to update stock balance."}
+                "properties": {
+                  "message": "Failed to update stock balance."
+                }
               }
             ]
           }
@@ -6856,7 +7364,9 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {"message": "Failed to fetch config."}
+                    "properties": {
+                      "message": "Failed to fetch config."
+                    }
                   }
                 ],
                 "configName": "beneficiaryRegistration"
@@ -6869,7 +7379,9 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {"message": "Failed to update household."}
+                    "properties": {
+                      "message": "Failed to update household."
+                    }
                   }
                 ]
               }
@@ -6880,8 +7392,7 @@ final dynamic sampleSMCFlows = {
                 "data": [
                   {
                     "key": "HouseholdClientReferenceId",
-                    "value":
-                        "{{contextData.entities.HouseholdModel.clientReferenceId}}"
+                    "value": "{{contextData.entities.HouseholdModel.clientReferenceId}}"
                   }
                 ],
                 "name": "householdOverview",
@@ -6889,7 +7400,9 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {"message": "Navigation failed."}
+                    "properties": {
+                      "message": "Navigation failed."
+                    }
                   }
                 ],
                 "navigationMode": "popUntilAndPush",
@@ -6897,7 +7410,10 @@ final dynamic sampleSMCFlows = {
               }
             }
           ],
-          "condition": {"type": "custom", "expression": "isEdit==true"}
+          "condition": {
+            "type": "custom",
+            "expression": "isEdit==true"
+          }
         },
         {
           "actions": [
@@ -6907,7 +7423,9 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {"message": "Failed to fetch config."}
+                    "properties": {
+                      "message": "Failed to fetch config."
+                    }
                   }
                 ],
                 "configName": "beneficiaryRegistration"
@@ -6934,7 +7452,9 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {"message": "Failed to create household."}
+                    "properties": {
+                      "message": "Failed to create household."
+                    }
                   }
                 ]
               }
@@ -6945,8 +7465,7 @@ final dynamic sampleSMCFlows = {
                 "data": [
                   {
                     "key": "HouseholdClientReferenceId",
-                    "value":
-                        "{{contextData.entities.HouseholdModel.clientReferenceId}}"
+                    "value": "{{contextData.entities.HouseholdModel.clientReferenceId}}"
                   }
                 ],
                 "name": "householdOverview",
@@ -6954,7 +7473,9 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {"message": "Navigation failed."}
+                    "properties": {
+                      "message": "Navigation failed."
+                    }
                   }
                 ],
                 "navigationMode": "popUntilAndPush",
@@ -6962,7 +7483,9 @@ final dynamic sampleSMCFlows = {
               }
             }
           ],
-          "condition": {"expression": "DEFAULT"}
+          "condition": {
+            "expression": "DEFAULT"
+          }
         }
       ],
       "isSelected": true,
@@ -6970,7 +7493,10 @@ final dynamic sampleSMCFlows = {
       "initActions": [],
       "wrapperConfig": {
         "filters": [
-          {"field": "isHeadOfHousehold", "equals": true}
+          {
+            "field": "isHeadOfHousehold",
+            "equals": true
+          }
         ],
         "relations": [
           {

--- a/apps/health_campaign_field_worker_app/lib/sampleJsonConfigs/registration_smc_flows.dart
+++ b/apps/health_campaign_field_worker_app/lib/sampleJsonConfigs/registration_smc_flows.dart
@@ -14,9 +14,7 @@ final dynamic sampleSMCFlows = {
           "heading": "DELIVERY_SUCCESSFUL_PANEL_CARD_HEADING",
           "fieldName": "successCard",
           "mandatory": true,
-          "properties": {
-            "type": "success"
-          },
+          "properties": {"type": "success"},
           "description": "DELIVERY_SUCCESSFUL_PANEL_CARD_DESC",
           "primaryAction": {
             "type": "template",
@@ -40,9 +38,7 @@ final dynamic sampleSMCFlows = {
             ],
             "fieldName": "viewHouseholdButton",
             "mandatory": true,
-            "properties": {
-              "type": "primary"
-            }
+            "properties": {"type": "primary"}
           },
           "secondaryAction": {
             "type": "template",
@@ -52,17 +48,12 @@ final dynamic sampleSMCFlows = {
             "onAction": [
               {
                 "actionType": "NAVIGATION",
-                "properties": {
-                  "name": "searchBeneficiary",
-                  "type": "TEMPLATE"
-                }
+                "properties": {"name": "searchBeneficiary", "type": "TEMPLATE"}
               }
             ],
             "fieldName": "goBack",
             "mandatory": true,
-            "properties": {
-              "type": "secondary"
-            }
+            "properties": {"type": "secondary"}
           },
           "primaryActionLabel": "VIEW_HOUSEHOLD_DETAILS",
           "secondaryActionLabel": "GO_BACK"
@@ -110,9 +101,7 @@ final dynamic sampleSMCFlows = {
           "heading": "REDOSE_SUCCESSFUL_PANEL_CARD_HEADING",
           "fieldName": "successCard",
           "mandatory": true,
-          "properties": {
-            "type": "success"
-          },
+          "properties": {"type": "success"},
           "description": "REDOSE_SUCCESSFUL_PANEL_CARD_DESC",
           "primaryAction": {
             "type": "template",
@@ -136,9 +125,7 @@ final dynamic sampleSMCFlows = {
             ],
             "fieldName": "viewHouseholdButton",
             "mandatory": true,
-            "properties": {
-              "type": "primary"
-            }
+            "properties": {"type": "primary"}
           },
           "secondaryAction": {
             "type": "template",
@@ -148,17 +135,12 @@ final dynamic sampleSMCFlows = {
             "onAction": [
               {
                 "actionType": "NAVIGATION",
-                "properties": {
-                  "name": "searchBeneficiary",
-                  "type": "TEMPLATE"
-                }
+                "properties": {"name": "searchBeneficiary", "type": "TEMPLATE"}
               }
             ],
             "fieldName": "goBack",
             "mandatory": true,
-            "properties": {
-              "type": "secondary"
-            }
+            "properties": {"type": "secondary"}
           },
           "primaryActionLabel": "VIEW_HOUSEHOLD_DETAILS",
           "secondaryActionLabel": "GO_BACK"
@@ -207,31 +189,38 @@ final dynamic sampleSMCFlows = {
               "data": [
                 {
                   "key": "NAME_OF_INDIVIDUAL",
-                  "value": "{{contextData.0.individuals.IndividualModel.name.givenName}}"
+                  "value":
+                      "{{contextData.0.individuals.IndividualModel.name.givenName}}"
                 },
                 {
                   "key": "ID_TYPE",
-                  "value": "{{contextData.0.individuals.IndividualModel.identifiers.0.identifierType}}"
+                  "value":
+                      "{{contextData.0.individuals.IndividualModel.identifiers.0.identifierType}}"
                 },
                 {
                   "key": "ID_NUMBER",
-                  "value": "{{contextData.0.individuals.IndividualModel.identifiers.0.identifierId}}"
+                  "value":
+                      "{{contextData.0.individuals.IndividualModel.identifiers.0.identifierId}}"
                 },
                 {
                   "key": "AGE",
-                  "value": "{{fn:formatDate(contextData.0.individuals.IndividualModel.dateOfBirth, 'age')}}"
+                  "value":
+                      "{{fn:formatDate(contextData.0.individuals.IndividualModel.dateOfBirth, 'age')}}"
                 },
                 {
                   "key": "GENDER",
-                  "value": "{{contextData.0.individuals.IndividualModel.gender}}"
+                  "value":
+                      "{{contextData.0.individuals.IndividualModel.gender}}"
                 },
                 {
                   "key": "MOBILE_NUMBER",
-                  "value": "{{contextData.0.individuals.IndividualModel.mobileNumber}}"
+                  "value":
+                      "{{contextData.0.individuals.IndividualModel.mobileNumber}}"
                 },
                 {
                   "key": "DATE_OF_REGISTRATION",
-                  "value": "{{fn:formatDate(contextData.0.projectBeneficiaries.ProjectBeneficiaryModel.dateOfRegistration, 'date', dd MMM yyyy)}}"
+                  "value":
+                      "{{fn:formatDate(contextData.0.projectBeneficiaries.ProjectBeneficiaryModel.dateOfRegistration, 'date', dd MMM yyyy)}}"
                 }
               ],
               "type": "template",
@@ -240,9 +229,7 @@ final dynamic sampleSMCFlows = {
             }
           ],
           "fieldName": "detailsCard",
-          "properties": {
-            "type": "primary"
-          },
+          "properties": {"type": "primary"},
           "schemaCode": null
         },
         {
@@ -266,12 +253,15 @@ final dynamic sampleSMCFlows = {
                       "@default": "REGISTRATION_CURRENT_DOSE_STATUS_PENDING",
                       "@condition": [
                         {
-                          "when": "{{fn:isDoseCompleted(item.id, contextData.0.currentRunningCycle)}} == true",
-                          "value": "REGISTRATION_CURRENT_DOSE_STATUS_ADMINISTERED"
+                          "when":
+                              "{{fn:isDoseCompleted(item.id, contextData.0.currentRunningCycle)}} == true",
+                          "value":
+                              "REGISTRATION_CURRENT_DOSE_STATUS_ADMINISTERED"
                         },
                         {
                           "when": "{{item.id}} == {{contextData.0.nextDoseId}}",
-                          "value": "REGISTRATION_CURRENT_DOSE_STATUS_TOBE_ADMINISTERED"
+                          "value":
+                              "REGISTRATION_CURRENT_DOSE_STATUS_TOBE_ADMINISTERED"
                         }
                       ]
                     }
@@ -279,7 +269,8 @@ final dynamic sampleSMCFlows = {
                   {
                     "header": "COMPLETED_ON",
                     "isActive": true,
-                    "cellValue": "{{fn:getTaskCompletionDate(item.id, contextData.0.currentRunningCycle)}}"
+                    "cellValue":
+                        "{{fn:getTaskCompletionDate(item.id, contextData.0.currentRunningCycle)}}"
                   }
                 ]
               },
@@ -303,9 +294,7 @@ final dynamic sampleSMCFlows = {
                         "value": "REGISTRATION_PAST_CYCLE {{item.id}}",
                         "format": "textTemplate",
                         "fieldName": "cycleNumber",
-                        "properties": {
-                          "style": "headingS"
-                        }
+                        "properties": {"style": "headingS"}
                       },
                       {
                         "data": {
@@ -320,11 +309,14 @@ final dynamic sampleSMCFlows = {
                               "header": "DELIVERY_STATUS",
                               "isActive": true,
                               "cellValue": {
-                                "@default": "REGISTRATION_PAST_DOSE_STATUS_PENDING",
+                                "@default":
+                                    "REGISTRATION_PAST_DOSE_STATUS_PENDING",
                                 "@condition": [
                                   {
-                                    "when": "{{fn:isDoseCompleted(item.id, currentItem.id)}} == true",
-                                    "value": "REGISTRATION_PAST_DOSE_STATUS_ADMINISTERED"
+                                    "when":
+                                        "{{fn:isDoseCompleted(item.id, currentItem.id)}} == true",
+                                    "value":
+                                        "REGISTRATION_PAST_DOSE_STATUS_ADMINISTERED"
                                   }
                                 ]
                               }
@@ -332,7 +324,8 @@ final dynamic sampleSMCFlows = {
                             {
                               "header": "COMPLETED_ON",
                               "isActive": true,
-                              "cellValue": "{{fn:getTaskCompletionDate(item.id, currentItem.id)}}"
+                              "cellValue":
+                                  "{{fn:getTaskCompletionDate(item.id, currentItem.id)}}"
                             }
                           ]
                         },
@@ -342,17 +335,13 @@ final dynamic sampleSMCFlows = {
                       }
                     ],
                     "fieldName": "card2",
-                    "properties": {
-                      "type": "secondary"
-                    }
+                    "properties": {"type": "secondary"}
                   },
                   "format": "listView",
                   "visible": "{{fn:length(contextData.0.pastCycles)}} > 0",
                   "fieldName": "pastCyclesList",
                   "dataSource": "pastCycles",
-                  "properties": {
-                    "spacing": "spacer4"
-                  }
+                  "properties": {"spacing": "spacer4"}
                 }
               ],
               "fieldName": "expandable",
@@ -362,9 +351,7 @@ final dynamic sampleSMCFlows = {
             }
           ],
           "fieldName": "card",
-          "properties": {
-            "type": "primary"
-          },
+          "properties": {"type": "primary"},
           "schemaCode": null
         }
       ],
@@ -375,7 +362,8 @@ final dynamic sampleSMCFlows = {
           "type": "template",
           "label": "RECORD_CYCLE_DOSE",
           "format": "actionPopup",
-          "visible": "{{fn:hasStockForDelivery(contextData.0.eligibleProductVariants)}} == false",
+          "visible":
+              "{{fn:hasStockForDelivery(contextData.0.eligibleProductVariants)}} == false",
           "fieldName": "insufficientStockPopUp",
           "properties": {
             "icon": "Warning",
@@ -391,10 +379,7 @@ final dynamic sampleSMCFlows = {
                   "fieldName": "insufficientStockMessageText",
                   "properties": {
                     "replaceAll": [
-                      {
-                        "searchValue": "::",
-                        "replaceValue": "\n"
-                      }
+                      {"searchValue": "::", "replaceValue": "\n"}
                     ],
                     "separatedBy": "::"
                   }
@@ -411,9 +396,7 @@ final dynamic sampleSMCFlows = {
                   "onAction": [
                     {
                       "actionType": "CLOSE_POPUP",
-                      "properties": {
-                        "parentScreenKey": "beneficiaryDetails"
-                      }
+                      "properties": {"parentScreenKey": "beneficiaryDetails"}
                     }
                   ],
                   "fieldName": "closePopUp",
@@ -437,8 +420,10 @@ final dynamic sampleSMCFlows = {
           "type": "template",
           "label": "RECORD_CYCLE_DOSE",
           "format": "button",
-          "visible": "{{fn:canRecordDelivery(contextData.0.nextCycleId)}}==true && {{fn:hasStockForDelivery(contextData.0.eligibleProductVariants)}} == true",
-          "disabled": "{{fn:hasStockForDelivery(contextData.0.eligibleProductVariants)}} == false",
+          "visible":
+              "{{fn:canRecordDelivery(contextData.0.nextCycleId)}}==true && {{fn:hasStockForDelivery(contextData.0.eligibleProductVariants)}} == true",
+          "disabled":
+              "{{fn:hasStockForDelivery(contextData.0.eligibleProductVariants)}} == false",
           "onAction": [
             {
               "actionType": "NAVIGATION",
@@ -446,7 +431,8 @@ final dynamic sampleSMCFlows = {
                 "data": [
                   {
                     "key": "ProjectBeneficiaryClientReferenceId",
-                    "value": "{{contextData.0.projectBeneficiaries.0.clientReferenceId}}"
+                    "value":
+                        "{{contextData.0.projectBeneficiaries.0.clientReferenceId}}"
                   },
                   {
                     "key": "HouseholdClientReferenceId",
@@ -458,28 +444,17 @@ final dynamic sampleSMCFlows = {
                   },
                   {
                     "key": "individualClientReferenceId",
-                    "value": "{{navigation.selectedIndividualClientReferenceId}}"
+                    "value":
+                        "{{navigation.selectedIndividualClientReferenceId}}"
                   },
                   {
                     "key": "beneficiaryId",
                     "value": "{{navigation.selectedIndividualIdentifierId}}"
                   },
-                  {
-                    "key": "childName",
-                    "value": "{{navigation.childName}}"
-                  },
-                  {
-                    "key": "ageInMonths",
-                    "value": "{{navigation.ageInMonths}}"
-                  },
-                  {
-                    "key": "gender",
-                    "value": "{{navigation.gender}}"
-                  },
-                  {
-                    "key": "headName",
-                    "value": "{{navigation.headName}}"
-                  },
+                  {"key": "childName", "value": "{{navigation.childName}}"},
+                  {"key": "ageInMonths", "value": "{{navigation.ageInMonths}}"},
+                  {"key": "gender", "value": "{{navigation.gender}}"},
+                  {"key": "headName", "value": "{{navigation.headName}}"},
                   {
                     "key": "headMobileNumber",
                     "value": "{{navigation.headMobileNumber}}"
@@ -488,13 +463,11 @@ final dynamic sampleSMCFlows = {
                     "key": "cycleIndex",
                     "value": "{{contextData.0.nextCycleId}}"
                   },
-                  {
-                    "key": "doseIndex",
-                    "value": "{{contextData.0.nextDoseId}}"
-                  },
+                  {"key": "doseIndex", "value": "{{contextData.0.nextDoseId}}"},
                   {
                     "key": "deliveryStrategy",
-                    "value": "{{contextData.0.currentDelivery.0.deliveryStrategy}}"
+                    "value":
+                        "{{contextData.0.currentDelivery.0.deliveryStrategy}}"
                   },
                   {
                     "key": "totalDosesInCycle",
@@ -527,10 +500,7 @@ final dynamic sampleSMCFlows = {
           "onAction": [
             {
               "actionType": "BACK_NAVIGATION",
-              "properties": {
-                "name": "householdOverview",
-                "type": "TEMPLATE"
-              }
+              "properties": {"name": "householdOverview", "type": "TEMPLATE"}
             }
           ]
         }
@@ -600,18 +570,12 @@ final dynamic sampleSMCFlows = {
               "else": 1,
               "then": {
                 "if": {
-                  "left": {
-                    "value": "{{dose}}",
-                    "operation": "increment"
-                  },
+                  "left": {"value": "{{dose}}", "operation": "increment"},
                   "right": "{{deliveryLength}}",
                   "operator": "lte"
                 },
                 "else": 1,
-                "then": {
-                  "value": "{{dose}}",
-                  "operation": "increment"
-                }
+                "then": {"value": "{{dose}}", "operation": "increment"}
               }
             }
           },
@@ -627,17 +591,11 @@ final dynamic sampleSMCFlows = {
               "else": "{{currentRunningCycle}}",
               "then": {
                 "if": {
-                  "left": {
-                    "value": "{{dose}}",
-                    "operation": "increment"
-                  },
+                  "left": {"value": "{{dose}}", "operation": "increment"},
                   "right": "{{deliveryLength}}",
                   "operator": "lte"
                 },
-                "else": {
-                  "value": "{{cycle}}",
-                  "operation": "increment"
-                },
+                "else": {"value": "{{cycle}}", "operation": "increment"},
                 "then": "{{cycle}}"
               }
             }
@@ -656,7 +614,8 @@ final dynamic sampleSMCFlows = {
             }
           },
           "deliveryLength": {
-            "from": "{{singleton.selectedProject.additionalDetails.projectType.cycles}}",
+            "from":
+                "{{singleton.selectedProject.additionalDetails.projectType.cycles}}",
             "order": 3,
             "where": {
               "left": "{{id}}",
@@ -677,19 +636,12 @@ final dynamic sampleSMCFlows = {
             }
           },
           "currentRunningCycle": {
-            "from": "{{singleton.selectedProject.additionalDetails.projectType.cycles}}",
+            "from":
+                "{{singleton.selectedProject.additionalDetails.projectType.cycles}}",
             "order": 1,
             "where": [
-              {
-                "left": "{{startDate}}",
-                "right": "{{now}}",
-                "operator": "lt"
-              },
-              {
-                "left": "{{endDate}}",
-                "right": "{{now}}",
-                "operator": "gt"
-              }
+              {"left": "{{startDate}}", "right": "{{now}}", "operator": "lt"},
+              {"left": "{{endDate}}", "right": "{{now}}", "operator": "gt"}
             ],
             "select": "{{id}}",
             "default": -1,
@@ -758,7 +710,8 @@ final dynamic sampleSMCFlows = {
         "wrapperName": "DeliveryWrapper",
         "computedList": {
           "pastCycles": {
-            "from": "{{singleton.selectedProject.additionalDetails.projectType.cycles}}",
+            "from":
+                "{{singleton.selectedProject.additionalDetails.projectType.cycles}}",
             "order": 6,
             "where": {
               "left": "{{item.id}}",
@@ -776,7 +729,8 @@ final dynamic sampleSMCFlows = {
             }
           },
           "targetCycle": {
-            "from": "{{singleton.selectedProject.additionalDetails.projectType.cycles}}",
+            "from":
+                "{{singleton.selectedProject.additionalDetails.projectType.cycles}}",
             "order": 1,
             "where": {
               "left": "{{id}}",
@@ -799,9 +753,7 @@ final dynamic sampleSMCFlows = {
           },
           "futureDeliveries": {
             "from": "{{targetCycle.0.deliveries}}",
-            "skip": {
-              "from": "{{effectiveDose}}"
-            },
+            "skip": {"from": "{{effectiveDose}}"},
             "order": 3,
             "where": {
               "left": "{{item.deliveryStrategy}}",
@@ -815,24 +767,12 @@ final dynamic sampleSMCFlows = {
             "fallback": [],
             "takeLast": false,
             "evaluateCondition": {
-              "context": [
-                "{{individuals.0}}",
-                "{{household.0}}"
-              ],
+              "context": ["{{individuals.0}}", "{{household.0}}"],
               "condition": "{{item.condition}}",
               "transformations": {
-                "age": {
-                  "type": "ageInMonths",
-                  "source": "dateOfBirth"
-                },
-                "height": {
-                  "type": "int",
-                  "source": "height"
-                },
-                "weight": {
-                  "type": "int",
-                  "source": "weight"
-                }
+                "age": {"type": "ageInMonths", "source": "dateOfBirth"},
+                "height": {"type": "int", "source": "height"},
+                "weight": {"type": "int", "source": "weight"}
               }
             }
           }
@@ -860,9 +800,7 @@ final dynamic sampleSMCFlows = {
           "heading": "REFERRAL_SUCCESSFUL_PANEL_CARD_HEADING",
           "fieldName": "successCard",
           "mandatory": true,
-          "properties": {
-            "type": "success"
-          },
+          "properties": {"type": "success"},
           "description": "REGISTRATION_ID_DESCRIPTION",
           "primaryAction": {
             "type": "template",
@@ -876,7 +814,8 @@ final dynamic sampleSMCFlows = {
                   "data": [
                     {
                       "key": "selectedIndividualClientReferenceId",
-                      "value": "{{navigation.selectedIndividualClientReferenceId}}"
+                      "value":
+                          "{{navigation.selectedIndividualClientReferenceId}}"
                     },
                     {
                       "key": "selectedIndividualIdentifierId",
@@ -894,13 +833,9 @@ final dynamic sampleSMCFlows = {
             ],
             "fieldName": "viewHouseholdButton",
             "mandatory": true,
-            "properties": {
-              "type": "primary"
-            }
+            "properties": {"type": "primary"}
           },
-          "descriptionArgs": [
-            "{{navigation.selectedIndividualIdentifierId}}"
-          ],
+          "descriptionArgs": ["{{navigation.selectedIndividualIdentifierId}}"],
           "secondaryAction": {
             "type": "template",
             "label": "GO_BACK",
@@ -909,17 +844,12 @@ final dynamic sampleSMCFlows = {
             "onAction": [
               {
                 "actionType": "NAVIGATION",
-                "properties": {
-                  "name": "searchBeneficiary",
-                  "type": "TEMPLATE"
-                }
+                "properties": {"name": "searchBeneficiary", "type": "TEMPLATE"}
               }
             ],
             "fieldName": "goBack",
             "mandatory": true,
-            "properties": {
-              "type": "secondary"
-            }
+            "properties": {"type": "secondary"}
           },
           "primaryActionLabel": "REFERRAL_VIEW_HOUSEHOLD_DETAILS",
           "secondaryActionLabel": "GO_BACK"
@@ -977,9 +907,7 @@ final dynamic sampleSMCFlows = {
                       "actionType": "REVERSE_TRANSFORM",
                       "properties": {
                         "configName": "beneficiaryRegistration",
-                        "entityTypes": [
-                          "HouseholdModel"
-                        ]
+                        "entityTypes": ["HouseholdModel"]
                       }
                     },
                     {
@@ -990,10 +918,7 @@ final dynamic sampleSMCFlows = {
                             "key": "HouseholdClientReferenceId",
                             "value": "{{ context.household.clientReferenceId }}"
                           },
-                          {
-                            "key": "isEdit",
-                            "value": "true"
-                          }
+                          {"key": "isEdit", "value": "true"}
                         ],
                         "name": "HOUSEHOLD",
                         "type": "FORM"
@@ -1012,25 +937,26 @@ final dynamic sampleSMCFlows = {
                 }
               ],
               "fieldName": "row",
-              "properties": {
-                "mainAxisAlignment": "end"
-              }
+              "properties": {"mainAxisAlignment": "end"}
             },
             {
               "data": [
                 {
                   "key": "HOUSEHOLD_HEAD_NAME",
-                  "value": "{{contextData.0.headIndividual.IndividualModel.name.givenName}}",
+                  "value":
+                      "{{contextData.0.headIndividual.IndividualModel.name.givenName}}",
                   "isActive": true
                 },
                 {
                   "key": "HOUSEHOLD_LOCALITY",
-                  "value": "{{contextData.0.household.HouseholdModel.address.locality.code}}",
+                  "value":
+                      "{{contextData.0.household.HouseholdModel.address.locality.code}}",
                   "isActive": true
                 },
                 {
                   "key": "MEMBER_COUNT",
-                  "value": "{{contextData.0.household.HouseholdModel.memberCount}}",
+                  "value":
+                      "{{contextData.0.household.HouseholdModel.memberCount}}",
                   "isActive": true
                 }
               ],
@@ -1058,7 +984,8 @@ final dynamic sampleSMCFlows = {
                         "type": "template",
                         "label": "REGISTRATION_EDIT_INDIVIDUAL_BUTTON_LABEL",
                         "format": "button",
-                        "disabled": "{{fn:disableEdit(item.task, item.hFReferral)}}==true",
+                        "disabled":
+                            "{{fn:disableEdit(item.task, item.hFReferral)}}==true",
                         "onAction": [
                           {
                             "actionType": "REVERSE_TRANSFORM",
@@ -1086,12 +1013,10 @@ final dynamic sampleSMCFlows = {
                               "data": [
                                 {
                                   "key": "HouseholdClientReferenceId",
-                                  "value": "{{item.member.0.householdClientReferenceId}}"
+                                  "value":
+                                      "{{item.member.0.householdClientReferenceId}}"
                                 },
-                                {
-                                  "key": "isEdit",
-                                  "value": "true"
-                                }
+                                {"key": "isEdit", "value": "true"}
                               ],
                               "name": "ADD_MEMBER",
                               "type": "FORM"
@@ -1118,71 +1043,63 @@ final dynamic sampleSMCFlows = {
                   },
                   {
                     "type": "template",
-                    "value": "{{item.individual.0.gender }} | {{fn:formatDate(item.individual.0.dateOfBirth, 'age')}}",
+                    "value":
+                        "{{item.individual.0.gender }} | {{fn:formatDate(item.individual.0.dateOfBirth, 'age')}}",
                     "format": "textTemplate",
                     "fieldName": "genderAge",
-                    "properties": {
-                      "bottomGap": 16
-                    }
+                    "properties": {"bottomGap": 16}
                   },
                   {
                     "type": "template",
                     "label": "{{fn:getInEligibleStatus(item.task)}}",
                     "format": "tag",
-                    "visible": "{{fn:checkEligibilityForAgeAndSideEffect(item.individual.0.dateOfBirth, item.task, contextData.0.currentRunningCycle)}}==false && {{fn:hasReferralForCurrentCycle(item.hFReferral)}}==false",
+                    "visible":
+                        "{{fn:checkEligibilityForAgeAndSideEffect(item.individual.0.dateOfBirth, item.task, contextData.0.currentRunningCycle)}}==false && {{fn:hasReferralForCurrentCycle(item.hFReferral)}}==false",
                     "fieldName": "notEligible",
-                    "properties": {
-                      "tagType": "error"
-                    }
+                    "properties": {"tagType": "error"}
                   },
                   {
                     "type": "template",
                     "label": "BENEFICIARY_REFERRED",
                     "format": "tag",
-                    "visible": "{{fn:hasReferralForCurrentCycle(item.hFReferral)}}==true",
+                    "visible":
+                        "{{fn:hasReferralForCurrentCycle(item.hFReferral)}}==true",
                     "fieldName": "beneficiaryReferred",
-                    "properties": {
-                      "tagType": "error"
-                    }
+                    "properties": {"tagType": "error"}
                   },
                   {
                     "type": "template",
                     "label": "ADMINISTERED_SUCCESS",
                     "format": "tag",
-                    "visible": "{{fn:isDelivered(item.task.last.status)}}==true && {{fn:hasRedoseForCurrentCycle(item.task)}}==false && {{fn:checkEligibilityForAgeAndSideEffect(item.individual.0.dateOfBirth, item.task, contextData.0.currentRunningCycle)}}==true && {{fn:hasReferralForCurrentCycle(item.hFReferral)}}==false",
+                    "visible":
+                        "{{fn:isDelivered(item.task.last.status)}}==true && {{fn:hasRedoseForCurrentCycle(item.task)}}==false && {{fn:checkEligibilityForAgeAndSideEffect(item.individual.0.dateOfBirth, item.task, contextData.0.currentRunningCycle)}}==true && {{fn:hasReferralForCurrentCycle(item.hFReferral)}}==false",
                     "fieldName": "administrationSuccess",
-                    "properties": {
-                      "tagType": "success",
-                      "bottomGap": 16
-                    }
+                    "properties": {"tagType": "success", "bottomGap": 16}
                   },
                   {
                     "type": "template",
                     "label": "REDOSE_COMPLETED",
                     "format": "tag",
-                    "visible": "{{fn:hasRedoseForCurrentCycle(item.task)}}==true && {{fn:checkEligibilityForAgeAndSideEffect(item.individual.0.dateOfBirth, item.task, contextData.0.currentRunningCycle)}}==true && {{fn:hasReferralForCurrentCycle(item.hFReferral)}}==false",
+                    "visible":
+                        "{{fn:hasRedoseForCurrentCycle(item.task)}}==true && {{fn:checkEligibilityForAgeAndSideEffect(item.individual.0.dateOfBirth, item.task, contextData.0.currentRunningCycle)}}==true && {{fn:hasReferralForCurrentCycle(item.hFReferral)}}==false",
                     "fieldName": "redoseCompleted",
-                    "properties": {
-                      "tagType": "success",
-                      "bottomGap": 16
-                    }
+                    "properties": {"tagType": "success", "bottomGap": 16}
                   },
                   {
                     "type": "template",
                     "label": "NOT_VISITED",
                     "format": "tag",
-                    "visible": "{{fn:checkEligibilityForAgeAndSideEffect(item.individual.0.dateOfBirth, item.task, contextData.0.currentRunningCycle)}}==true && {{fn:isDelivered(item.task.last.status)}}==false && {{fn:hasReferralForCurrentCycle(item.hFReferral)}}==false && {{fn:hasUnableToDeliverForCurrentCycle(item.task)}}==false && {{fn:hasRedoseForCurrentCycle(item.task)}}==false",
+                    "visible":
+                        "{{fn:checkEligibilityForAgeAndSideEffect(item.individual.0.dateOfBirth, item.task, contextData.0.currentRunningCycle)}}==true && {{fn:isDelivered(item.task.last.status)}}==false && {{fn:hasReferralForCurrentCycle(item.hFReferral)}}==false && {{fn:hasUnableToDeliverForCurrentCycle(item.task)}}==false && {{fn:hasRedoseForCurrentCycle(item.task)}}==false",
                     "fieldName": "notVisited",
-                    "properties": {
-                      "tagType": "info",
-                      "bottomGap": 16
-                    }
+                    "properties": {"tagType": "info", "bottomGap": 16}
                   },
                   {
                     "type": "template",
                     "label": "DELIVERY",
                     "format": "button",
-                    "visible": "{{fn:checkEligibilityForAgeAndSideEffect(item.individual.0.dateOfBirth, item.task,contextData.0.currentRunningCycle)}} == true  && {{fn:checkAllDoseDelivered(item.task)}} == false && {{fn:hasReferralForCurrentCycle(item.hFReferral)}}==false && {{fn:hasRedoseForCurrentCycle(item.task)}}==false",
+                    "visible":
+                        "{{fn:checkEligibilityForAgeAndSideEffect(item.individual.0.dateOfBirth, item.task,contextData.0.currentRunningCycle)}} == true  && {{fn:checkAllDoseDelivered(item.task)}} == false && {{fn:hasReferralForCurrentCycle(item.hFReferral)}}==false && {{fn:hasRedoseForCurrentCycle(item.task)}}==false",
                     "onAction": [
                       {
                         "actionType": "NAVIGATION",
@@ -1194,15 +1111,18 @@ final dynamic sampleSMCFlows = {
                             },
                             {
                               "key": "selectedIndividualIdentifierId",
-                              "value": "{{item.individual.0.identifiers.0.identifierId}}"
+                              "value":
+                                  "{{item.individual.0.identifiers.0.identifierId}}"
                             },
                             {
                               "key": "HouseholdClientReferenceId",
-                              "value": "{{item.member.0.householdClientReferenceId}}"
+                              "value":
+                                  "{{item.member.0.householdClientReferenceId}}"
                             },
                             {
                               "key": "ProjectBeneficiaryClientReferenceId",
-                              "value": "{{item.projectBeneficiary.0.clientReferenceId}}"
+                              "value":
+                                  "{{item.projectBeneficiary.0.clientReferenceId}}"
                             },
                             {
                               "key": "selectedIndividualName",
@@ -1214,7 +1134,8 @@ final dynamic sampleSMCFlows = {
                             },
                             {
                               "key": "selectedIndividualAgeInMonths",
-                              "value": "{{fn:formatDate(item.individual.0.dateOfBirth, 'ageInMonths')}}"
+                              "value":
+                                  "{{fn:formatDate(item.individual.0.dateOfBirth, 'ageInMonths')}}"
                             },
                             {
                               "key": "cycleIndex",
@@ -1240,7 +1161,8 @@ final dynamic sampleSMCFlows = {
                     "type": "template",
                     "label": "HOUSEHOLD_OVERVIEW_UNABLE_TO_DELIVER_LABEL",
                     "format": "button",
-                    "visible": "{{fn:checkEligibilityForAgeAndSideEffect(item.individual.0.dateOfBirth, item.task, contextData.0.currentRunningCycle)}} == true && {{fn:checkAllDoseDelivered(item.task)}} == false && {{fn:hasReferralForCurrentCycle(item.hFReferral)}}==false",
+                    "visible":
+                        "{{fn:checkEligibilityForAgeAndSideEffect(item.individual.0.dateOfBirth, item.task, contextData.0.currentRunningCycle)}} == true && {{fn:checkAllDoseDelivered(item.task)}} == false && {{fn:hasReferralForCurrentCycle(item.hFReferral)}}==false",
                     "onAction": [
                       {
                         "actionType": "NAVIGATION",
@@ -1252,11 +1174,13 @@ final dynamic sampleSMCFlows = {
                             },
                             {
                               "key": "HouseholdClientReferenceId",
-                              "value": "{{item.member.0.householdClientReferenceId}}"
+                              "value":
+                                  "{{item.member.0.householdClientReferenceId}}"
                             },
                             {
                               "key": "ProjectBeneficiaryClientReferenceId",
-                              "value": "{{item.projectBeneficiary.0.clientReferenceId}}"
+                              "value":
+                                  "{{item.projectBeneficiary.0.clientReferenceId}}"
                             },
                             {
                               "key": "cycleIndex",
@@ -1283,7 +1207,8 @@ final dynamic sampleSMCFlows = {
                     "type": "template",
                     "label": "REGISTRATION_VIEW_DETAILS",
                     "format": "button",
-                    "visible": "{{fn:checkEligibilityForAgeAndSideEffect(item.individual.0.dateOfBirth, item.task,contextData.0.currentRunningCycle)}} == true &&  {{fn:checkAllDoseDelivered(item.task)}} == true && {{fn:hasReferralForCurrentCycle(item.hFReferral)}}==false",
+                    "visible":
+                        "{{fn:checkEligibilityForAgeAndSideEffect(item.individual.0.dateOfBirth, item.task,contextData.0.currentRunningCycle)}} == true &&  {{fn:checkAllDoseDelivered(item.task)}} == true && {{fn:hasReferralForCurrentCycle(item.hFReferral)}}==false",
                     "onAction": [
                       {
                         "actionType": "NAVIGATION",
@@ -1295,15 +1220,18 @@ final dynamic sampleSMCFlows = {
                             },
                             {
                               "key": "selectedIndividualIdentifierId",
-                              "value": "{{item.individual.0.identifiers.0.identifierId}}"
+                              "value":
+                                  "{{item.individual.0.identifiers.0.identifierId}}"
                             },
                             {
                               "key": "HouseholdClientReferenceId",
-                              "value": "{{item.member.0.householdClientReferenceId}}"
+                              "value":
+                                  "{{item.member.0.householdClientReferenceId}}"
                             },
                             {
                               "key": "ProjectBeneficiaryClientReferenceId",
-                              "value": "{{item.projectBeneficiary.0.clientReferenceId}}"
+                              "value":
+                                  "{{item.projectBeneficiary.0.clientReferenceId}}"
                             },
                             {
                               "key": "selectedIndividualName",
@@ -1315,7 +1243,8 @@ final dynamic sampleSMCFlows = {
                             },
                             {
                               "key": "selectedIndividualAgeInMonths",
-                              "value": "{{fn:formatDate(item.individual.0.dateOfBirth, 'ageInMonths')}}"
+                              "value":
+                                  "{{fn:formatDate(item.individual.0.dateOfBirth, 'ageInMonths')}}"
                             },
                             {
                               "key": "cycleIndex",
@@ -1341,7 +1270,8 @@ final dynamic sampleSMCFlows = {
                     "type": "template",
                     "label": "REDOSE_ADMINISTRATION",
                     "format": "button",
-                    "visible": "{{fn:checkEligibilityForAgeAndSideEffect(item.individual.0.dateOfBirth, item.task,contextData.0.currentRunningCycle)}} == true && {{fn:checkAllDoseDelivered(item.task)}} == true && {{fn:hasReferralForCurrentCycle(item.hFReferral)}}==false && {{fn:hasRedoseForCurrentCycle(item.task)}}==false",
+                    "visible":
+                        "{{fn:checkEligibilityForAgeAndSideEffect(item.individual.0.dateOfBirth, item.task,contextData.0.currentRunningCycle)}} == true && {{fn:checkAllDoseDelivered(item.task)}} == true && {{fn:hasReferralForCurrentCycle(item.hFReferral)}}==false && {{fn:hasRedoseForCurrentCycle(item.task)}}==false",
                     "disabled": "{{fn:isRedoseWindowExpired(item.task)}}==true",
                     "onAction": [
                       {
@@ -1354,15 +1284,18 @@ final dynamic sampleSMCFlows = {
                             },
                             {
                               "key": "selectedIndividualIdentifierId",
-                              "value": "{{item.individual.0.identifiers.0.identifierId}}"
+                              "value":
+                                  "{{item.individual.0.identifiers.0.identifierId}}"
                             },
                             {
                               "key": "HouseholdClientReferenceId",
-                              "value": "{{item.member.0.householdClientReferenceId}}"
+                              "value":
+                                  "{{item.member.0.householdClientReferenceId}}"
                             },
                             {
                               "key": "ProjectBeneficiaryClientReferenceId",
-                              "value": "{{item.projectBeneficiary.0.clientReferenceId}}"
+                              "value":
+                                  "{{item.projectBeneficiary.0.clientReferenceId}}"
                             },
                             {
                               "key": "selectedIndividualName",
@@ -1374,7 +1307,8 @@ final dynamic sampleSMCFlows = {
                             },
                             {
                               "key": "selectedIndividualAgeInMonths",
-                              "value": "{{fn:formatDate(item.individual.0.dateOfBirth, 'ageInMonths')}}"
+                              "value":
+                                  "{{fn:formatDate(item.individual.0.dateOfBirth, 'ageInMonths')}}"
                             },
                             {
                               "key": "cycleIndex",
@@ -1412,15 +1346,14 @@ final dynamic sampleSMCFlows = {
               "hidden": false,
               "fieldName": "listViewMembers",
               "dataSource": "members",
-              "properties": {
-                "spacing": "spacer4"
-              }
+              "properties": {"spacing": "spacer4"}
             },
             {
               "type": "template",
               "label": "ADD_MEMBER",
               "format": "actionPopup",
-              "visible": "{{fn:hasMinimumBeneficiaryId(singleton.beneficiaryIdMinCount, uniqueIdPoolCount)}}==false",
+              "visible":
+                  "{{fn:hasMinimumBeneficiaryId(singleton.beneficiaryIdMinCount, uniqueIdPoolCount)}}==false",
               "fieldName": "beneficiaryIdMinCheck",
               "properties": {
                 "size": "medium",
@@ -1429,19 +1362,20 @@ final dynamic sampleSMCFlows = {
                 "popupConfig": {
                   "body": [],
                   "type": "alert",
-                  "title": "REGISTRATION_SEARCH_BENEFICIARY_MIN_BENEFICIARY_ID_LEFT_TITLE",
-                  "description": "REGISTRATION_SEARCH_BENEFICIARY_MIN_BENEFICIARY_ID_LEFT_DESCRIPTION",
+                  "title":
+                      "REGISTRATION_SEARCH_BENEFICIARY_MIN_BENEFICIARY_ID_LEFT_TITLE",
+                  "description":
+                      "REGISTRATION_SEARCH_BENEFICIARY_MIN_BENEFICIARY_ID_LEFT_DESCRIPTION",
                   "footerActions": [
                     {
                       "type": "template",
-                      "label": "REGISTRATION_SEARCH_BENEFICIARY_SKIP_CONTINUE_LABEL",
+                      "label":
+                          "REGISTRATION_SEARCH_BENEFICIARY_SKIP_CONTINUE_LABEL",
                       "format": "button",
                       "onAction": [
                         {
                           "actionType": "CLOSE_POPUP",
-                          "properties": {
-                            "parentScreenKey": "searchBeneficiary"
-                          }
+                          "properties": {"parentScreenKey": "searchBeneficiary"}
                         },
                         {
                           "actionType": "NAVIGATION",
@@ -1449,7 +1383,8 @@ final dynamic sampleSMCFlows = {
                             "data": [
                               {
                                 "key": "HouseholdClientReferenceId",
-                                "value": "{{contextData.0.household.HouseholdModel.clientReferenceId}}"
+                                "value":
+                                    "{{contextData.0.household.HouseholdModel.clientReferenceId}}"
                               },
                               {
                                 "key": "UNIQUE_BENEFICIARY_ID",
@@ -1475,9 +1410,7 @@ final dynamic sampleSMCFlows = {
                       "onAction": [
                         {
                           "actionType": "CLOSE_POPUP",
-                          "properties": {
-                            "parentScreenKey": "searchBeneficiary"
-                          }
+                          "properties": {"parentScreenKey": "searchBeneficiary"}
                         },
                         {
                           "actionType": "NAVIGATE_TO_BENEFICIARY_ID_DOWN_SYNC",
@@ -1504,7 +1437,8 @@ final dynamic sampleSMCFlows = {
               "type": "template",
               "label": "ADD_MEMBER",
               "format": "button",
-              "visible": "{{fn:hasMinimumBeneficiaryId(singleton.beneficiaryIdMinCount, uniqueIdPoolCount)}}==true",
+              "visible":
+                  "{{fn:hasMinimumBeneficiaryId(singleton.beneficiaryIdMinCount, uniqueIdPoolCount)}}==true",
               "onAction": [
                 {
                   "actionType": "NAVIGATION",
@@ -1512,7 +1446,8 @@ final dynamic sampleSMCFlows = {
                     "data": [
                       {
                         "key": "HouseholdClientReferenceId",
-                        "value": "{{contextData.0.household.HouseholdModel.clientReferenceId}}"
+                        "value":
+                            "{{contextData.0.household.HouseholdModel.clientReferenceId}}"
                       },
                       {
                         "key": "UNIQUE_BENEFICIARY_ID",
@@ -1535,10 +1470,7 @@ final dynamic sampleSMCFlows = {
             }
           ],
           "fieldName": "card",
-          "properties": {
-            "type": "primary",
-            "cardType": "primary"
-          },
+          "properties": {"type": "primary", "cardType": "primary"},
           "schemaCode": null
         }
       ],
@@ -1552,10 +1484,7 @@ final dynamic sampleSMCFlows = {
           "onAction": [
             {
               "actionType": "NAVIGATION",
-              "properties": {
-                "name": "searchBeneficiary",
-                "type": "TEMPLATE"
-              }
+              "properties": {"name": "searchBeneficiary", "type": "TEMPLATE"}
             }
           ]
         }
@@ -1566,9 +1495,7 @@ final dynamic sampleSMCFlows = {
       "screenType": "TEMPLATE",
       "description": "REGISTRATION_HOUSEHOLD_OVERVIEW_DESC",
       "initActions": [
-        {
-          "actionType": "LOAD_UNIQUE_ID_POOL"
-        },
+        {"actionType": "LOAD_UNIQUE_ID_POOL"},
         {
           "actionType": "SEARCH_EVENT",
           "properties": {
@@ -1588,19 +1515,12 @@ final dynamic sampleSMCFlows = {
         "filters": [],
         "computed": {
           "currentRunningCycle": {
-            "from": "{{singleton.selectedProject.additionalDetails.projectType.cycles}}",
+            "from":
+                "{{singleton.selectedProject.additionalDetails.projectType.cycles}}",
             "order": 1,
             "where": [
-              {
-                "left": "{{startDate}}",
-                "right": "{{now}}",
-                "operator": "lt"
-              },
-              {
-                "left": "{{endDate}}",
-                "right": "{{now}}",
-                "operator": "gt"
-              }
+              {"left": "{{startDate}}", "right": "{{now}}", "operator": "lt"},
+              {"left": "{{endDate}}", "right": "{{now}}", "operator": "gt"}
             ],
             "select": "{{id}}",
             "default": -1,
@@ -1624,10 +1544,7 @@ final dynamic sampleSMCFlows = {
             },
             "entity": "HouseholdMemberModel",
             "filters": [
-              {
-                "field": "isHeadOfHousehold",
-                "equals": true
-              }
+              {"field": "isHeadOfHousehold", "equals": true}
             ]
           },
           {
@@ -1742,30 +1659,18 @@ final dynamic sampleSMCFlows = {
           "heading": "UNABLETODELIVERY_FLOW_SCREEN_HEADING",
           "summary": false,
           "version": 1,
-          "navigateTo": {
-            "name": "household-overview",
-            "type": "template"
-          },
+          "navigateTo": {"name": "household-overview", "type": "template"},
           "properties": [
             {
               "type": "string",
               "enums": [
-                {
-                  "code": "BENEFICIARY_DIED",
-                  "name": "BENEFICIARY_DIED"
-                },
+                {"code": "BENEFICIARY_DIED", "name": "BENEFICIARY_DIED"},
                 {
                   "code": "BENEFICIARY_MIGRATED",
                   "name": "BENEFICIARY_MIGRATED"
                 },
-                {
-                  "code": "BENEFICIARY_ABSENT",
-                  "name": "BENEFICIARY_ABSENT"
-                },
-                {
-                  "code": "BENEFICIARY_REFUSED",
-                  "name": "BENEFICIARY_REFUSED"
-                }
+                {"code": "BENEFICIARY_ABSENT", "name": "BENEFICIARY_ABSENT"},
+                {"code": "BENEFICIARY_REFUSED", "name": "BENEFICIARY_REFUSED"}
               ],
               "label": "UNABLETODELIVERY_FLOW_reason_LABEL",
               "order": 1,
@@ -1787,7 +1692,8 @@ final dynamic sampleSMCFlows = {
                 {
                   "type": "required",
                   "value": true,
-                  "message": "UNABLETODELIVERY_FLOW_reason_REQUIRED_ERROR_MESSAGE"
+                  "message":
+                      "UNABLETODELIVERY_FLOW_reason_REQUIRED_ERROR_MESSAGE"
                 }
               ],
               "errorMessage": "REGISTRATION_UNABLETODELIVER_reason_ERROR"
@@ -1832,10 +1738,7 @@ final dynamic sampleSMCFlows = {
                 "value": "BENEFICIARY_ABSENT_STATUS",
                 "expression": "unableToDeliver.reason == BENEFICIARY_ABSENT"
               },
-              {
-                "value": "BENEFICIARY_REFUSED_STATUS",
-                "expression": "DEFAULT"
-              }
+              {"value": "BENEFICIARY_REFUSED_STATUS", "expression": "DEFAULT"}
             ],
             "description": "UNABLETODELIVER_FLOWT_ALERT_DESCRIPTION",
             "primaryActionLabel": "UNABLETODELIVER_FLOW_ACTION_SUBMIT",
@@ -1859,10 +1762,7 @@ final dynamic sampleSMCFlows = {
                 "key": "ProjectBeneficiaryClientReferenceId",
                 "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
               },
-              {
-                "key": "cycleIndex",
-                "value": "{{navigation.cycleIndex}}"
-              }
+              {"key": "cycleIndex", "value": "{{navigation.cycleIndex}}"}
             ],
             "onError": [
               {
@@ -1882,9 +1782,7 @@ final dynamic sampleSMCFlows = {
             "onError": [
               {
                 "actionType": "SHOW_TOAST",
-                "properties": {
-                  "message": "Failed to create household."
-                }
+                "properties": {"message": "Failed to create household."}
               }
             ]
           }
@@ -1934,11 +1832,7 @@ final dynamic sampleSMCFlows = {
               "actionType": "field.value==true ? SEARCH_EVENT : CLEAR_STATE",
               "properties": {
                 "data": [
-                  {
-                    "key": "",
-                    "value": 5,
-                    "operation": "within"
-                  },
+                  {"key": "", "value": 5, "operation": "within"},
                   {
                     "key": "localityBoundaryCode",
                     "root": "address",
@@ -1970,13 +1864,8 @@ final dynamic sampleSMCFlows = {
             {
               "actionType": "CLEAR_STATE",
               "properties": {
-                "filterKeys": [
-                  "givenName",
-                  "identifierId"
-                ],
-                "widgetKeys": [
-                  "searchBar"
-                ],
+                "filterKeys": ["givenName", "identifierId"],
+                "widgetKeys": ["searchBar"],
                 "triggerSearch": true
               }
             }
@@ -2016,10 +1905,7 @@ final dynamic sampleSMCFlows = {
           "mandatory": true,
           "debounceMs": 300,
           "validations": [
-            {
-              "type": "minSearchChars",
-              "value": 2
-            }
+            {"type": "minSearchChars", "value": 2}
           ],
           "minSearchChars": 2
         },
@@ -2053,10 +1939,7 @@ final dynamic sampleSMCFlows = {
           "fieldName": "idSearchBar",
           "mandatory": true,
           "validations": [
-            {
-              "type": "minSearchChars",
-              "value": 3
-            }
+            {"type": "minSearchChars", "value": 3}
           ],
           "minSearchChars": 3
         },
@@ -2084,10 +1967,7 @@ final dynamic sampleSMCFlows = {
                       "code": "BENEFICIARY_REFERRED",
                       "name": "REGISTRATION_BENEFICIARY_REFERRED"
                     },
-                    {
-                      "code": "INELIGIBLE",
-                      "name": "REGISTRATION_INELIGIBLE"
-                    },
+                    {"code": "INELIGIBLE", "name": "REGISTRATION_INELIGIBLE"},
                     {
                       "code": "CLOSED_HOUSEHOLD",
                       "name": "REGISTRATION_CLOSED_HOUSEHOLD"
@@ -2119,9 +1999,7 @@ final dynamic sampleSMCFlows = {
                           "projectBeneficiary",
                           "projectId"
                         ],
-                        "widgetKeys": [
-                          "selectedStatus"
-                        ],
+                        "widgetKeys": ["selectedStatus"],
                         "triggerSearch": true
                       }
                     }
@@ -2135,14 +2013,13 @@ final dynamic sampleSMCFlows = {
                 },
                 {
                   "type": "template",
-                  "label": "REGISTRATION_SEARCH_BENEFICIARY_FILTER_FILTER_LABEL",
+                  "label":
+                      "REGISTRATION_SEARCH_BENEFICIARY_FILTER_FILTER_LABEL",
                   "format": "button",
                   "onAction": [
                     {
                       "actionType": "CLOSE_POPUP",
-                      "properties": {
-                        "parentScreenKey": "searchBeneficiary"
-                      }
+                      "properties": {"parentScreenKey": "searchBeneficiary"}
                     },
                     {
                       "actionType": "CLEAR_STATE",
@@ -2179,7 +2056,8 @@ final dynamic sampleSMCFlows = {
                         }
                       ],
                       "condition": {
-                        "expression": "selectedStatus == ADMINISTRATION_SUCCESS || selectedStatus == CLOSED_HOUSEHOLD || selectedStatus == ADMINISTRATION_FAILED || selectedStatus == INELIGIBLE"
+                        "expression":
+                            "selectedStatus == ADMINISTRATION_SUCCESS || selectedStatus == CLOSED_HOUSEHOLD || selectedStatus == ADMINISTRATION_FAILED || selectedStatus == INELIGIBLE"
                       }
                     },
                     {
@@ -2323,9 +2201,7 @@ final dynamic sampleSMCFlows = {
                           },
                           {
                             "actionType": "CREATE_EVENT",
-                            "properties": {
-                              "entity": "ProjectBeneficiaryModel"
-                            }
+                            "properties": {"entity": "ProjectBeneficiaryModel"}
                           },
                           {
                             "actionType": "NAVIGATION",
@@ -2333,7 +2209,8 @@ final dynamic sampleSMCFlows = {
                               "data": [
                                 {
                                   "key": "HouseholdClientReferenceId",
-                                  "value": "{{ item.HouseholdModel.clientReferenceId }}"
+                                  "value":
+                                      "{{ item.HouseholdModel.clientReferenceId }}"
                                 }
                               ],
                               "name": "householdOverview",
@@ -2342,7 +2219,8 @@ final dynamic sampleSMCFlows = {
                           }
                         ],
                         "condition": {
-                          "expression": "{{fn:length(item.projectBeneficiaries)}}<=0"
+                          "expression":
+                              "{{fn:length(item.projectBeneficiaries)}}<=0"
                         }
                       },
                       {
@@ -2353,7 +2231,8 @@ final dynamic sampleSMCFlows = {
                               "data": [
                                 {
                                   "key": "HouseholdClientReferenceId",
-                                  "value": "{{ item.HouseholdModel.clientReferenceId }}"
+                                  "value":
+                                      "{{ item.HouseholdModel.clientReferenceId }}"
                                 }
                               ],
                               "name": "householdOverview",
@@ -2362,7 +2241,8 @@ final dynamic sampleSMCFlows = {
                           }
                         ],
                         "condition": {
-                          "expression": "{{item.tasks.0.status}} != CLOSED_HOUSEHOLD"
+                          "expression":
+                              "{{item.tasks.0.status}} != CLOSED_HOUSEHOLD"
                         }
                       },
                       {
@@ -2371,16 +2251,10 @@ final dynamic sampleSMCFlows = {
                             "actionType": "REVERSE_TRANSFORM",
                             "properties": {
                               "data": [
-                                {
-                                  "key": "entities",
-                                  "value": "{{item}}"
-                                }
+                                {"key": "entities", "value": "{{item}}"}
                               ],
                               "configName": "beneficiaryRegistration",
-                              "entityTypes": [
-                                "HouseholdModel",
-                                "TaskModel"
-                              ]
+                              "entityTypes": ["HouseholdModel", "TaskModel"]
                             }
                           },
                           {
@@ -2389,16 +2263,11 @@ final dynamic sampleSMCFlows = {
                               "data": [
                                 {
                                   "key": "HouseholdClientReferenceId",
-                                  "value": "{{ item.HouseholdModel.clientReferenceId }}"
+                                  "value":
+                                      "{{ item.HouseholdModel.clientReferenceId }}"
                                 },
-                                {
-                                  "key": "isEdit",
-                                  "value": "true"
-                                },
-                                {
-                                  "key": "isClosedHousehold",
-                                  "value": "true"
-                                }
+                                {"key": "isEdit", "value": "true"},
+                                {"key": "isClosedHousehold", "value": "true"}
                               ],
                               "name": "HOUSEHOLD",
                               "type": "FORM"
@@ -2406,15 +2275,13 @@ final dynamic sampleSMCFlows = {
                           }
                         ],
                         "condition": {
-                          "expression": "{{item.tasks.0.status}} == CLOSED_HOUSEHOLD"
+                          "expression":
+                              "{{item.tasks.0.status}} == CLOSED_HOUSEHOLD"
                         }
                       }
                     ],
                     "fieldName": "openMemberCard",
-                    "properties": {
-                      "size": "medium",
-                      "type": "secondary"
-                    }
+                    "properties": {"size": "medium", "type": "secondary"}
                   }
                 ],
                 "fieldName": "detailsRow",
@@ -2458,9 +2325,7 @@ final dynamic sampleSMCFlows = {
           "format": "listView",
           "hidden": false,
           "fieldName": "listView",
-          "properties": {
-            "spacing": "spacer4"
-          },
+          "properties": {"spacing": "spacer4"},
           "schemaCode": null
         }
       ],
@@ -2472,7 +2337,8 @@ final dynamic sampleSMCFlows = {
           "type": "template",
           "label": "DOWNLOAD_BENEFICIARY_IDS",
           "format": "actionPopup",
-          "visible": "{{fn:hasMinimumBeneficiaryId(singleton.beneficiaryIdMinCount, uniqueIdPoolCount)}}==false",
+          "visible":
+              "{{fn:hasMinimumBeneficiaryId(singleton.beneficiaryIdMinCount, uniqueIdPoolCount)}}==false",
           "disabled": "{{searchBar}} == null || {{searchBar}} == ''",
           "fieldName": "beneficiaryIdMinCheck",
           "properties": {
@@ -2482,28 +2348,26 @@ final dynamic sampleSMCFlows = {
             "popupConfig": {
               "body": [],
               "type": "alert",
-              "title": "REGISTRATION_SEARCH_BENEFICIARY_MIN_BENEFICIARY_ID_LEFT_TITLE",
-              "description": "REGISTRATION_SEARCH_BENEFICIARY_MIN_BENEFICIARY_ID_LEFT_DESCRIPTION",
+              "title":
+                  "REGISTRATION_SEARCH_BENEFICIARY_MIN_BENEFICIARY_ID_LEFT_TITLE",
+              "description":
+                  "REGISTRATION_SEARCH_BENEFICIARY_MIN_BENEFICIARY_ID_LEFT_DESCRIPTION",
               "footerActions": [
                 {
                   "type": "template",
-                  "label": "REGISTRATION_SEARCH_BENEFICIARY_SKIP_CONTINUE_LABEL",
+                  "label":
+                      "REGISTRATION_SEARCH_BENEFICIARY_SKIP_CONTINUE_LABEL",
                   "format": "button",
                   "onAction": [
                     {
                       "actionType": "CLOSE_POPUP",
-                      "properties": {
-                        "parentScreenKey": "searchBeneficiary"
-                      }
+                      "properties": {"parentScreenKey": "searchBeneficiary"}
                     },
                     {
                       "actionType": "NAVIGATION",
                       "properties": {
                         "data": [
-                          {
-                            "key": "nameOfIndividual",
-                            "value": "{{searchBar}}"
-                          },
+                          {"key": "nameOfIndividual", "value": "{{searchBar}}"},
                           {
                             "key": "UNIQUE_BENEFICIARY_ID",
                             "value": "{{latestBeneficiaryId}}"
@@ -2532,9 +2396,7 @@ final dynamic sampleSMCFlows = {
                   "onAction": [
                     {
                       "actionType": "CLOSE_POPUP",
-                      "properties": {
-                        "parentScreenKey": "searchBeneficiary"
-                      }
+                      "properties": {"parentScreenKey": "searchBeneficiary"}
                     },
                     {
                       "actionType": "NAVIGATE_TO_BENEFICIARY_ID_DOWN_SYNC",
@@ -2561,17 +2423,15 @@ final dynamic sampleSMCFlows = {
           "type": "template",
           "label": "REGISTER_BENEFICIARY",
           "format": "button",
-          "visible": "{{fn:hasMinimumBeneficiaryId(singleton.beneficiaryIdMinCount, uniqueIdPoolCount)}}==true",
+          "visible":
+              "{{fn:hasMinimumBeneficiaryId(singleton.beneficiaryIdMinCount, uniqueIdPoolCount)}}==true",
           "disabled": "{{searchBar}} == null || {{searchBar}} == ''",
           "onAction": [
             {
               "actionType": "NAVIGATION",
               "properties": {
                 "data": [
-                  {
-                    "key": "nameOfIndividual",
-                    "value": "{{searchBar}}"
-                  },
+                  {"key": "nameOfIndividual", "value": "{{searchBar}}"},
                   {
                     "key": "UNIQUE_BENEFICIARY_ID",
                     "value": "{{latestBeneficiaryId}}"
@@ -2651,10 +2511,7 @@ final dynamic sampleSMCFlows = {
               "value": 1,
               "message": "SCANLIMIT_ERROR_MESSAGE"
             },
-            {
-              "type": "isGS1",
-              "value": false
-            }
+            {"type": "isGS1", "value": false}
           ],
           "scanLimit.message": "SCANLIMIT_ERROR_MESSAGE"
         }
@@ -2666,10 +2523,7 @@ final dynamic sampleSMCFlows = {
           "onAction": [
             {
               "actionType": "BACK_NAVIGATION",
-              "properties": {
-                "name": "HOME",
-                "type": "HOME"
-              }
+              "properties": {"name": "HOME", "type": "HOME"}
             }
           ]
         }
@@ -2680,9 +2534,7 @@ final dynamic sampleSMCFlows = {
       "screenType": "TEMPLATE",
       "description": "REGISTRATION_SEARCH_BENEFICIARY_DESC",
       "initActions": [
-        {
-          "actionType": "LOAD_UNIQUE_ID_POOL"
-        }
+        {"actionType": "LOAD_UNIQUE_ID_POOL"}
       ],
       "wrapperConfig": {
         "filters": [],
@@ -2703,10 +2555,7 @@ final dynamic sampleSMCFlows = {
             },
             "entity": "HouseholdMemberModel",
             "filters": [
-              {
-                "field": "isHeadOfHousehold",
-                "equals": true
-              }
+              {"field": "isHeadOfHousehold", "equals": true}
             ]
           },
           {
@@ -2769,10 +2618,7 @@ final dynamic sampleSMCFlows = {
             "task"
           ],
           "primary": "household",
-          "pagination": {
-            "limit": 5,
-            "maxItems": 15
-          }
+          "pagination": {"limit": 5, "maxItems": 15}
         }
       },
       "scrollListener": {
@@ -2781,10 +2627,7 @@ final dynamic sampleSMCFlows = {
           {
             "actionType": "REFRESH_SEARCH",
             "properties": {
-              "pagination": {
-                "limit": 5,
-                "maxItems": 15
-              }
+              "pagination": {"limit": 5, "maxItems": 15}
             }
           }
         ],
@@ -2793,10 +2636,7 @@ final dynamic sampleSMCFlows = {
           {
             "actionType": "REFRESH_SEARCH",
             "properties": {
-              "pagination": {
-                "limit": 5,
-                "maxItems": 15
-              }
+              "pagination": {"limit": 5, "maxItems": 15}
             }
           }
         ],
@@ -2818,7 +2658,8 @@ final dynamic sampleSMCFlows = {
           "order": 2,
           "footer": [
             {
-              "label": "APPONE_DELIVERYFLOW_DELIVERYDETAILS_ACTIONS_SUBMIT_LABEL",
+              "label":
+                  "APPONE_DELIVERYFLOW_DELIVERYDETAILS_ACTIONS_SUBMIT_LABEL",
               "format": "button",
               "onAction": [
                 {
@@ -2838,7 +2679,8 @@ final dynamic sampleSMCFlows = {
             }
           ],
           "module": "REGISTRATION",
-          "heading": "APPONE_DELIVERYFLOW_DELIVERYDETAILS_ACTIONS_SCREEN_HEADING",
+          "heading":
+              "APPONE_DELIVERYFLOW_DELIVERYDETAILS_ACTIONS_SCREEN_HEADING",
           "summary": false,
           "version": 1,
           "onAction": [
@@ -2848,16 +2690,11 @@ final dynamic sampleSMCFlows = {
                 "data": [
                   {
                     "key": "ProjectBeneficiaryClientReferenceId",
-                    "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                    "value":
+                        "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                   },
-                  {
-                    "key": "cycleIndex",
-                    "value": "{{navigation.cycleIndex}}"
-                  },
-                  {
-                    "key": "doseIndex",
-                    "value": "{{navigation.doseIndex}}"
-                  },
+                  {"key": "cycleIndex", "value": "{{navigation.cycleIndex}}"},
+                  {"key": "doseIndex", "value": "{{navigation.doseIndex}}"},
                   {
                     "key": "deliveryStrategy",
                     "value": "{{navigation.deliveryStrategy}}"
@@ -2880,9 +2717,7 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {
-                      "message": "Failed to create delivery task."
-                    }
+                    "properties": {"message": "Failed to create delivery task."}
                   }
                 ]
               }
@@ -2894,9 +2729,7 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {
-                      "message": "Failed to update stock balance."
-                    }
+                    "properties": {"message": "Failed to update stock balance."}
                   }
                 ]
               }
@@ -2909,7 +2742,8 @@ final dynamic sampleSMCFlows = {
                     "data": [
                       {
                         "key": "ProjectBeneficiaryClientReferenceId",
-                        "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                        "value":
+                            "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                       },
                       {
                         "key": "cycleIndex",
@@ -2964,9 +2798,7 @@ final dynamic sampleSMCFlows = {
                   }
                 }
               ],
-              "condition": {
-                "expression": "doseIndex == 1"
-              }
+              "condition": {"expression": "doseIndex == 1"}
             },
             {
               "actionType": "NAVIGATION",
@@ -2974,7 +2806,8 @@ final dynamic sampleSMCFlows = {
                 "data": [
                   {
                     "key": "ProjectBeneficiaryClientReferenceId",
-                    "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                    "value":
+                        "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                   },
                   {
                     "key": "HouseholdClientReferenceId",
@@ -3065,8 +2898,10 @@ final dynamic sampleSMCFlows = {
               "errorMessage": ""
             }
           ],
-          "actionLabel": "APPONE_DELIVERYFLOW_DELIVERYDETAILS_ACTIONS_SUBMIT_LABEL",
-          "description": "APPONE_DELIVERYFLOW_DELIVERYDETAILS_ACTIONS_SCREEN_DESCRIPTION",
+          "actionLabel":
+              "APPONE_DELIVERYFLOW_DELIVERYDETAILS_ACTIONS_SUBMIT_LABEL",
+          "description":
+              "APPONE_DELIVERYFLOW_DELIVERYDETAILS_ACTIONS_SCREEN_DESCRIPTION",
           "showTabView": false,
           "submitCondition": null,
           "preventScreenCapture": false,
@@ -3081,7 +2916,8 @@ final dynamic sampleSMCFlows = {
           "order": 1,
           "footer": [
             {
-              "label": "APPONE_REGISTRATION_DELIVERYDETAILS_ACTION_BUTTON_LABEL_1",
+              "label":
+                  "APPONE_REGISTRATION_DELIVERYDETAILS_ACTION_BUTTON_LABEL_1",
               "format": "button",
               "onAction": [
                 {
@@ -3111,16 +2947,11 @@ final dynamic sampleSMCFlows = {
                 "data": [
                   {
                     "key": "ProjectBeneficiaryClientReferenceId",
-                    "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                    "value":
+                        "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                   },
-                  {
-                    "key": "cycleIndex",
-                    "value": "{{navigation.cycleIndex}}"
-                  },
-                  {
-                    "key": "doseIndex",
-                    "value": "{{navigation.doseIndex}}"
-                  },
+                  {"key": "cycleIndex", "value": "{{navigation.cycleIndex}}"},
+                  {"key": "doseIndex", "value": "{{navigation.doseIndex}}"},
                   {
                     "key": "deliveryStrategy",
                     "value": "{{navigation.deliveryStrategy}}"
@@ -3143,9 +2974,7 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {
-                      "message": "Failed to create delivery task."
-                    }
+                    "properties": {"message": "Failed to create delivery task."}
                   }
                 ]
               }
@@ -3157,9 +2986,7 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {
-                      "message": "Failed to update stock balance."
-                    }
+                    "properties": {"message": "Failed to update stock balance."}
                   }
                 ]
               }
@@ -3172,7 +2999,8 @@ final dynamic sampleSMCFlows = {
                     "data": [
                       {
                         "key": "ProjectBeneficiaryClientReferenceId",
-                        "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                        "value":
+                            "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                       },
                       {
                         "key": "cycleIndex",
@@ -3227,9 +3055,7 @@ final dynamic sampleSMCFlows = {
                   }
                 }
               ],
-              "condition": {
-                "expression": "doseIndex == 1"
-              }
+              "condition": {"expression": "doseIndex == 1"}
             },
             {
               "actionType": "NAVIGATION",
@@ -3237,7 +3063,8 @@ final dynamic sampleSMCFlows = {
                 "data": [
                   {
                     "key": "ProjectBeneficiaryClientReferenceId",
-                    "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                    "value":
+                        "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                   },
                   {
                     "key": "HouseholdClientReferenceId",
@@ -3249,9 +3076,7 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {
-                      "message": "Navigation failed."
-                    }
+                    "properties": {"message": "Navigation failed."}
                   }
                 ],
                 "navigationMode": "popUntilAndPush",
@@ -3259,14 +3084,12 @@ final dynamic sampleSMCFlows = {
               }
             }
           ],
-          "navigateTo": {
-            "name": "DeliveryChecklist",
-            "type": "template"
-          },
+          "navigateTo": {"name": "DeliveryChecklist", "type": "template"},
           "properties": [
             {
               "type": "string",
-              "label": "APPONE_REGISTRATION_DELIVERYDETAILS_label_dateOfDelivery",
+              "label":
+                  "APPONE_REGISTRATION_DELIVERYDETAILS_label_dateOfDelivery",
               "order": 1,
               "value": "",
               "format": "date",
@@ -3291,22 +3114,10 @@ final dynamic sampleSMCFlows = {
             {
               "type": "dynamic",
               "enums": [
-                {
-                  "code": "SP1",
-                  "name": "SP1"
-                },
-                {
-                  "code": "SP2",
-                  "name": "SP2"
-                },
-                {
-                  "code": "AQ1",
-                  "name": "AQ1"
-                },
-                {
-                  "code": "AQ2",
-                  "name": "AQ2"
-                }
+                {"code": "SP1", "name": "SP1"},
+                {"code": "SP2", "name": "SP2"},
+                {"code": "AQ1", "name": "AQ1"},
+                {"code": "AQ2", "name": "AQ2"}
               ],
               "label": "APPONE_REGISTRATION_DELIVERYDETAILS_label_resource",
               "order": 2,
@@ -3336,30 +3147,20 @@ final dynamic sampleSMCFlows = {
               "includeInForm": true,
               "isMultiSelect": false,
               "dropDownOptions": [
-                {
-                  "code": "SP1",
-                  "name": "SP1"
-                },
-                {
-                  "code": "SP2",
-                  "name": "SP2"
-                },
-                {
-                  "code": "AQ1",
-                  "name": "AQ1"
-                },
-                {
-                  "code": "AQ2",
-                  "name": "AQ2"
-                }
+                {"code": "SP1", "name": "SP1"},
+                {"code": "SP2", "name": "SP2"},
+                {"code": "AQ1", "name": "AQ1"},
+                {"code": "AQ2", "name": "AQ2"}
               ],
               "includeInSummary": true,
-              "required.message": "REGISTRATION_RESOURCE_CARD_SELECTION_REQUIRED"
+              "required.message":
+                  "REGISTRATION_RESOURCE_CARD_SELECTION_REQUIRED"
             },
             {
               "type": "string",
               "enums": null,
-              "label": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_deliveryComments",
+              "label":
+                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_deliveryComments",
               "order": 3,
               "value": "",
               "format": "dropdown",
@@ -3382,8 +3183,10 @@ final dynamic sampleSMCFlows = {
               "includeInSummary": true
             }
           ],
-          "actionLabel": "APPONE_REGISTRATION_DELIVERYDETAILS_ACTION_BUTTON_LABEL_1",
-          "description": "APPONE_REGISTRATION_DELIVERYDETAILS_SCREEN_DESCRIPTION",
+          "actionLabel":
+              "APPONE_REGISTRATION_DELIVERYDETAILS_ACTION_BUTTON_LABEL_1",
+          "description":
+              "APPONE_REGISTRATION_DELIVERYDETAILS_SCREEN_DESCRIPTION",
           "showTabView": false,
           "submitCondition": null,
           "preventScreenCapture": false
@@ -3402,14 +3205,8 @@ final dynamic sampleSMCFlows = {
                 "key": "ProjectBeneficiaryClientReferenceId",
                 "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
               },
-              {
-                "key": "cycleIndex",
-                "value": "{{navigation.cycleIndex}}"
-              },
-              {
-                "key": "doseIndex",
-                "value": "{{navigation.doseIndex}}"
-              },
+              {"key": "cycleIndex", "value": "{{navigation.cycleIndex}}"},
+              {"key": "doseIndex", "value": "{{navigation.doseIndex}}"},
               {
                 "key": "deliveryStrategy",
                 "value": "{{navigation.deliveryStrategy}}"
@@ -3418,9 +3215,7 @@ final dynamic sampleSMCFlows = {
             "onError": [
               {
                 "actionType": "SHOW_TOAST",
-                "properties": {
-                  "message": "REGISTRATION_DELIVERY_MESSAGE"
-                }
+                "properties": {"message": "REGISTRATION_DELIVERY_MESSAGE"}
               }
             ],
             "configName": "delivery"
@@ -3432,9 +3227,7 @@ final dynamic sampleSMCFlows = {
             "onError": [
               {
                 "actionType": "SHOW_TOAST",
-                "properties": {
-                  "message": "Failed to create delivery task."
-                }
+                "properties": {"message": "Failed to create delivery task."}
               }
             ]
           }
@@ -3446,9 +3239,7 @@ final dynamic sampleSMCFlows = {
             "onError": [
               {
                 "actionType": "SHOW_TOAST",
-                "properties": {
-                  "message": "Failed to update stock balance."
-                }
+                "properties": {"message": "Failed to update stock balance."}
               }
             ]
           }
@@ -3461,20 +3252,15 @@ final dynamic sampleSMCFlows = {
                 "data": [
                   {
                     "key": "ProjectBeneficiaryClientReferenceId",
-                    "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                    "value":
+                        "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                   },
-                  {
-                    "key": "cycleIndex",
-                    "value": "{{navigation.cycleIndex}}"
-                  },
+                  {"key": "cycleIndex", "value": "{{navigation.cycleIndex}}"},
                   {
                     "key": "deliveryStrategy",
                     "value": "{{navigation.deliveryStrategy}}"
                   },
-                  {
-                    "key": "futureDoses",
-                    "value": "{{navigation.futureDoses}}"
-                  }
+                  {"key": "futureDoses", "value": "{{navigation.futureDoses}}"}
                 ],
                 "onError": [
                   {
@@ -3494,9 +3280,7 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {
-                      "message": "Failed to create bulk tasks."
-                    }
+                    "properties": {"message": "Failed to create bulk tasks."}
                   }
                 ]
               }
@@ -3508,17 +3292,13 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {
-                      "message": "Failed to update stock balance."
-                    }
+                    "properties": {"message": "Failed to update stock balance."}
                   }
                 ]
               }
             }
           ],
-          "condition": {
-            "expression": "doseIndex == 1"
-          }
+          "condition": {"expression": "doseIndex == 1"}
         },
         {
           "actionType": "NAVIGATION",
@@ -3538,9 +3318,7 @@ final dynamic sampleSMCFlows = {
             "onError": [
               {
                 "actionType": "SHOW_TOAST",
-                "properties": {
-                  "message": "Navigation failed."
-                }
+                "properties": {"message": "Navigation failed."}
               }
             ],
             "navigationMode": "popUntilAndPush",
@@ -3597,12 +3375,10 @@ final dynamic sampleSMCFlows = {
                 "data": [
                   {
                     "key": "ProjectBeneficiaryClientReferenceId",
-                    "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                    "value":
+                        "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                   },
-                  {
-                    "key": "cycleIndex",
-                    "value": "{{navigation.cycleIndex}}"
-                  },
+                  {"key": "cycleIndex", "value": "{{navigation.cycleIndex}}"},
                   {
                     "key": "lastDeliveredTaskClientReferenceId",
                     "value": "{{navigation.lastDeliveredTaskClientReferenceId}}"
@@ -3627,9 +3403,7 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {
-                      "message": "Failed to create redose task."
-                    }
+                    "properties": {"message": "Failed to create redose task."}
                   }
                 ]
               }
@@ -3641,9 +3415,7 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {
-                      "message": "Failed to update stock balance."
-                    }
+                    "properties": {"message": "Failed to update stock balance."}
                   }
                 ]
               }
@@ -3654,7 +3426,8 @@ final dynamic sampleSMCFlows = {
                 "data": [
                   {
                     "key": "ProjectBeneficiaryClientReferenceId",
-                    "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                    "value":
+                        "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                   },
                   {
                     "key": "HouseholdClientReferenceId",
@@ -3705,22 +3478,10 @@ final dynamic sampleSMCFlows = {
             {
               "type": "dynamic",
               "enums": [
-                {
-                  "code": "SP1",
-                  "name": "SP1"
-                },
-                {
-                  "code": "SP2",
-                  "name": "SP2"
-                },
-                {
-                  "code": "AQ1",
-                  "name": "AQ1"
-                },
-                {
-                  "code": "AQ2",
-                  "name": "AQ2"
-                }
+                {"code": "SP1", "name": "SP1"},
+                {"code": "SP2", "name": "SP2"},
+                {"code": "AQ1", "name": "AQ1"},
+                {"code": "AQ2", "name": "AQ2"}
               ],
               "label": "REDOSE_RESOURCE_DELIVERED",
               "order": 2,
@@ -3744,36 +3505,18 @@ final dynamic sampleSMCFlows = {
               "includeInForm": true,
               "isMultiSelect": false,
               "dropDownOptions": [
-                {
-                  "code": "SP1",
-                  "name": "SP1"
-                },
-                {
-                  "code": "SP2",
-                  "name": "SP2"
-                },
-                {
-                  "code": "AQ1",
-                  "name": "AQ1"
-                },
-                {
-                  "code": "AQ2",
-                  "name": "AQ2"
-                }
+                {"code": "SP1", "name": "SP1"},
+                {"code": "SP2", "name": "SP2"},
+                {"code": "AQ1", "name": "AQ1"},
+                {"code": "AQ2", "name": "AQ2"}
               ],
               "includeInSummary": true
             },
             {
               "type": "string",
               "enums": [
-                {
-                  "code": "VOMITTING",
-                  "name": "REDOSE_REASON_VOMITTING"
-                },
-                {
-                  "code": "OTHERS",
-                  "name": "REDOSE_REASON_OTHERS"
-                }
+                {"code": "VOMITTING", "name": "REDOSE_REASON_VOMITTING"},
+                {"code": "OTHERS", "name": "REDOSE_REASON_OTHERS"}
               ],
               "label": "REDOSE_REASON",
               "order": 3,
@@ -3828,9 +3571,7 @@ final dynamic sampleSMCFlows = {
               "includeInSummary": true,
               "visibilityCondition": {
                 "expression": [
-                  {
-                    "condition": "RedoseDetails.reasonForRedose==OTHERS"
-                  }
+                  {"condition": "RedoseDetails.reasonForRedose==OTHERS"}
                 ]
               }
             }
@@ -3856,10 +3597,7 @@ final dynamic sampleSMCFlows = {
                 "key": "ProjectBeneficiaryClientReferenceId",
                 "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
               },
-              {
-                "key": "cycleIndex",
-                "value": "{{navigation.cycleIndex}}"
-              },
+              {"key": "cycleIndex", "value": "{{navigation.cycleIndex}}"},
               {
                 "key": "lastDeliveredTaskClientReferenceId",
                 "value": "{{navigation.lastDeliveredTaskClientReferenceId}}"
@@ -3868,9 +3606,7 @@ final dynamic sampleSMCFlows = {
             "onError": [
               {
                 "actionType": "SHOW_TOAST",
-                "properties": {
-                  "message": "REGISTRATION_REDOSE_MESSAGE"
-                }
+                "properties": {"message": "REGISTRATION_REDOSE_MESSAGE"}
               }
             ],
             "configName": "redose"
@@ -3884,25 +3620,7 @@ final dynamic sampleSMCFlows = {
             "onError": [
               {
                 "actionType": "SHOW_TOAST",
-                "properties": {
-                  "message": "Failed to create redose task."
-                }
-              }
-            ]
-          }
-        },
-        {
-          // Redose consumes another vial from stock (same pattern as the
-          // DELIVERY flow at line ~2741). Without this the balance stays at
-          // the pre-redose value even though the task+resource carry
-          // isDelivered=true, so StockBalanceExecutor never gets to deduct.
-          "actionType": "UPDATE_STOCK_BALANCE",
-          "properties": {
-            "entity": "TaskModel",
-            "onError": [
-              {
-                "actionType": "SHOW_TOAST",
-                "properties": {"message": "Failed to update stock balance."}
+                "properties": {"message": "Failed to create redose task."}
               }
             ]
           }
@@ -3925,9 +3643,7 @@ final dynamic sampleSMCFlows = {
             "onError": [
               {
                 "actionType": "SHOW_TOAST",
-                "properties": {
-                  "message": "Navigation failed."
-                }
+                "properties": {"message": "Navigation failed."}
               }
             ],
             "navigationMode": "popUntilAndPush",
@@ -3954,7 +3670,8 @@ final dynamic sampleSMCFlows = {
           "order": 1,
           "footer": [
             {
-              "label": "APPONE_REGISTRATION_DELIVERYDETAILS_ACTION_BUTTON_LABEL_1",
+              "label":
+                  "APPONE_REGISTRATION_DELIVERYDETAILS_ACTION_BUTTON_LABEL_1",
               "format": "button",
               "onAction": [
                 {
@@ -3986,7 +3703,8 @@ final dynamic sampleSMCFlows = {
                     "data": [
                       {
                         "key": "selectedIndividualClientReferenceId",
-                        "value": "{{navigation.selectedIndividualClientReferenceId}}"
+                        "value":
+                            "{{navigation.selectedIndividualClientReferenceId}}"
                       },
                       {
                         "key": "selectedIndividualIdentifierId",
@@ -3998,7 +3716,8 @@ final dynamic sampleSMCFlows = {
                       },
                       {
                         "key": "ProjectBeneficiaryClientReferenceId",
-                        "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                        "value":
+                            "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                       }
                     ],
                     "name": "beneficiaryDetails",
@@ -4017,7 +3736,8 @@ final dynamic sampleSMCFlows = {
                 }
               ],
               "condition": {
-                "expression": "eligibilityChecklist.ec1==NO && eligibilityChecklist.ec3==NO && eligibilityChecklist.ec4==NO"
+                "expression":
+                    "eligibilityChecklist.ec1==NO && eligibilityChecklist.ec3==NO && eligibilityChecklist.ec4==NO"
               }
             },
             {
@@ -4028,7 +3748,8 @@ final dynamic sampleSMCFlows = {
                     "data": [
                       {
                         "key": "selectedIndividualClientReferenceId",
-                        "value": "{{navigation.selectedIndividualClientReferenceId}}"
+                        "value":
+                            "{{navigation.selectedIndividualClientReferenceId}}"
                       },
                       {
                         "key": "selectedIndividualIdentifierId",
@@ -4040,7 +3761,8 @@ final dynamic sampleSMCFlows = {
                       },
                       {
                         "key": "ProjectBeneficiaryClientReferenceId",
-                        "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                        "value":
+                            "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                       },
                       {
                         "key": "selectedIndividualName",
@@ -4075,7 +3797,8 @@ final dynamic sampleSMCFlows = {
                 }
               ],
               "condition": {
-                "expression": "eligibilityChecklist.ec1==YES && eligibilityChecklist.ec3==YES && eligibilityChecklist.ec4==YES"
+                "expression":
+                    "eligibilityChecklist.ec1==YES && eligibilityChecklist.ec3==YES && eligibilityChecklist.ec4==YES"
               }
             },
             {
@@ -4086,7 +3809,8 @@ final dynamic sampleSMCFlows = {
                     "data": [
                       {
                         "key": "selectedIndividualClientReferenceId",
-                        "value": "{{navigation.selectedIndividualClientReferenceId}}"
+                        "value":
+                            "{{navigation.selectedIndividualClientReferenceId}}"
                       },
                       {
                         "key": "selectedIndividualIdentifierId",
@@ -4098,7 +3822,8 @@ final dynamic sampleSMCFlows = {
                       },
                       {
                         "key": "ProjectBeneficiaryClientReferenceId",
-                        "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                        "value":
+                            "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                       }
                     ],
                     "onError": [
@@ -4132,7 +3857,8 @@ final dynamic sampleSMCFlows = {
                     "data": [
                       {
                         "key": "selectedIndividualClientReferenceId",
-                        "value": "{{navigation.selectedIndividualClientReferenceId}}"
+                        "value":
+                            "{{navigation.selectedIndividualClientReferenceId}}"
                       },
                       {
                         "key": "selectedIndividualIdentifierId",
@@ -4144,7 +3870,8 @@ final dynamic sampleSMCFlows = {
                       },
                       {
                         "key": "ProjectBeneficiaryClientReferenceId",
-                        "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                        "value":
+                            "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                       }
                     ],
                     "name": "householdOverview",
@@ -4152,9 +3879,7 @@ final dynamic sampleSMCFlows = {
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {
-                          "message": "Navigation to flow failed."
-                        }
+                        "properties": {"message": "Navigation to flow failed."}
                       }
                     ],
                     "navigationMode": "popUntilAndPush",
@@ -4163,7 +3888,8 @@ final dynamic sampleSMCFlows = {
                 }
               ],
               "condition": {
-                "expression": "eligibilityChecklist.ec1==NO && eligibilityChecklist.ec3==NO && eligibilityChecklist.ec4==YES"
+                "expression":
+                    "eligibilityChecklist.ec1==NO && eligibilityChecklist.ec3==NO && eligibilityChecklist.ec4==YES"
               }
             },
             {
@@ -4174,7 +3900,8 @@ final dynamic sampleSMCFlows = {
                     "data": [
                       {
                         "key": "selectedIndividualClientReferenceId",
-                        "value": "{{navigation.selectedIndividualClientReferenceId}}"
+                        "value":
+                            "{{navigation.selectedIndividualClientReferenceId}}"
                       },
                       {
                         "key": "selectedIndividualIdentifierId",
@@ -4186,7 +3913,8 @@ final dynamic sampleSMCFlows = {
                       },
                       {
                         "key": "ProjectBeneficiaryClientReferenceId",
-                        "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                        "value":
+                            "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                       },
                       {
                         "key": "selectedIndividualName",
@@ -4210,9 +3938,7 @@ final dynamic sampleSMCFlows = {
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {
-                          "message": "Navigation failed."
-                        }
+                        "properties": {"message": "Navigation failed."}
                       }
                     ],
                     "navigationMode": "popUntilAndPush",
@@ -4220,9 +3946,7 @@ final dynamic sampleSMCFlows = {
                   }
                 }
               ],
-              "condition": {
-                "expression": "DEFAULT"
-              }
+              "condition": {"expression": "DEFAULT"}
             }
           ],
           "navigateTo": {
@@ -4233,14 +3957,8 @@ final dynamic sampleSMCFlows = {
             {
               "type": "string",
               "enums": [
-                {
-                  "code": "YES",
-                  "name": "QUESTION_1_YES"
-                },
-                {
-                  "code": "NO",
-                  "name": "QUESTION_1_NO"
-                }
+                {"code": "YES", "name": "QUESTION_1_YES"},
+                {"code": "NO", "name": "QUESTION_1_NO"}
               ],
               "label": "APPONE_ELIGIBILITYCHECKLIST_QUESTION_1_LABEL",
               "order": 1,
@@ -4263,36 +3981,26 @@ final dynamic sampleSMCFlows = {
                 {
                   "type": "required",
                   "value": true,
-                  "message": "APPONE_ELIGIBILITYCHECKLIST_QUESTION_1_LABEL_REQUIRED_MESSAGE"
+                  "message":
+                      "APPONE_ELIGIBILITYCHECKLIST_QUESTION_1_LABEL_REQUIRED_MESSAGE"
                 }
               ],
               "errorMessage": "REGISTRATION_CHECKLIST_ec1_ERROR",
               "includeInForm": true,
               "isMultiSelect": false,
               "dropDownOptions": [
-                {
-                  "code": "YES",
-                  "name": "QUESTION_1_YES"
-                },
-                {
-                  "code": "NO",
-                  "name": "QUESTION_1_NO"
-                }
+                {"code": "YES", "name": "QUESTION_1_YES"},
+                {"code": "NO", "name": "QUESTION_1_NO"}
               ],
               "includeInSummary": true,
-              "required.message": "APPONE_ELIGIBILITYCHECKLIST_QUESTION_1_LABEL_REQUIRED_MESSAGE"
+              "required.message":
+                  "APPONE_ELIGIBILITYCHECKLIST_QUESTION_1_LABEL_REQUIRED_MESSAGE"
             },
             {
               "type": "string",
               "enums": [
-                {
-                  "code": "YES",
-                  "name": "QUESTION_2_YES"
-                },
-                {
-                  "code": "NO",
-                  "name": "QUESTION_2_NO"
-                }
+                {"code": "YES", "name": "QUESTION_2_YES"},
+                {"code": "NO", "name": "QUESTION_2_NO"}
               ],
               "label": "APPONE_ELIGIBILITYCHECKLIST_QUESTION_2_LABEL",
               "order": 2,
@@ -4315,43 +4023,31 @@ final dynamic sampleSMCFlows = {
                 {
                   "type": "required",
                   "value": true,
-                  "message": "APPONE_ELIGIBILITYCHECKLIST_QUESTION_2_LABEL_REQUIRED_MESSAGE"
+                  "message":
+                      "APPONE_ELIGIBILITYCHECKLIST_QUESTION_2_LABEL_REQUIRED_MESSAGE"
                 }
               ],
               "errorMessage": "REGISTRATION_CHECKLIST_ec2_ERROR",
               "includeInForm": true,
               "isMultiSelect": false,
               "dropDownOptions": [
-                {
-                  "code": "YES",
-                  "name": "QUESTION_2_YES"
-                },
-                {
-                  "code": "NO",
-                  "name": "QUESTION_2_NO"
-                }
+                {"code": "YES", "name": "QUESTION_2_YES"},
+                {"code": "NO", "name": "QUESTION_2_NO"}
               ],
               "includeInSummary": true,
-              "required.message": "APPONE_ELIGIBILITYCHECKLIST_QUESTION_2_LABEL_REQUIRED_MESSAGE",
+              "required.message":
+                  "APPONE_ELIGIBILITYCHECKLIST_QUESTION_2_LABEL_REQUIRED_MESSAGE",
               "visibilityCondition": {
                 "expression": [
-                  {
-                    "condition": "eligibilityChecklist.ec1==YES"
-                  }
+                  {"condition": "eligibilityChecklist.ec1==YES"}
                 ]
               }
             },
             {
               "type": "string",
               "enums": [
-                {
-                  "code": "YES",
-                  "name": "QUESTION_3_YES"
-                },
-                {
-                  "code": "NO",
-                  "name": "QUESTION_3_NO"
-                }
+                {"code": "YES", "name": "QUESTION_3_YES"},
+                {"code": "NO", "name": "QUESTION_3_NO"}
               ],
               "label": "APPONE_ELIGIBILITYCHECKLIST_QUESTION_3_LABEL",
               "order": 3,
@@ -4374,36 +4070,26 @@ final dynamic sampleSMCFlows = {
                 {
                   "type": "required",
                   "value": true,
-                  "message": "APPONE_ELIGIBILITYCHECKLIST_QUESTION_3_LABEL_REQUIRED_MESSAGE"
+                  "message":
+                      "APPONE_ELIGIBILITYCHECKLIST_QUESTION_3_LABEL_REQUIRED_MESSAGE"
                 }
               ],
               "errorMessage": "REGISTRATION_CHECKLIST_ec3_ERROR",
               "includeInForm": true,
               "isMultiSelect": false,
               "dropDownOptions": [
-                {
-                  "code": "YES",
-                  "name": "QUESTION_3_YES"
-                },
-                {
-                  "code": "NO",
-                  "name": "QUESTION_3_NO"
-                }
+                {"code": "YES", "name": "QUESTION_3_YES"},
+                {"code": "NO", "name": "QUESTION_3_NO"}
               ],
               "includeInSummary": true,
-              "required.message": "APPONE_ELIGIBILITYCHECKLIST_QUESTION_3_LABEL_REQUIRED_MESSAGE"
+              "required.message":
+                  "APPONE_ELIGIBILITYCHECKLIST_QUESTION_3_LABEL_REQUIRED_MESSAGE"
             },
             {
               "type": "string",
               "enums": [
-                {
-                  "code": "YES",
-                  "name": "QUESTION_4_YES"
-                },
-                {
-                  "code": "NO",
-                  "name": "QUESTION_4_NO"
-                }
+                {"code": "YES", "name": "QUESTION_4_YES"},
+                {"code": "NO", "name": "QUESTION_4_NO"}
               ],
               "label": "APPONE_ELIGIBILITYCHECKLIST_QUESTION_4_LABEL",
               "order": 3,
@@ -4426,27 +4112,24 @@ final dynamic sampleSMCFlows = {
                 {
                   "type": "required",
                   "value": true,
-                  "message": "APPONE_ELIGIBILITYCHECKLIST_QUESTION_4_LABEL_REQUIRED_MESSAGE"
+                  "message":
+                      "APPONE_ELIGIBILITYCHECKLIST_QUESTION_4_LABEL_REQUIRED_MESSAGE"
                 }
               ],
               "errorMessage": "REGISTRATION_CHECKLIST_ec4_ERROR",
               "includeInForm": true,
               "isMultiSelect": false,
               "dropDownOptions": [
-                {
-                  "code": "YES",
-                  "name": "QUESTION_4_YES"
-                },
-                {
-                  "code": "NO",
-                  "name": "QUESTION_4_NO"
-                }
+                {"code": "YES", "name": "QUESTION_4_YES"},
+                {"code": "NO", "name": "QUESTION_4_NO"}
               ],
               "includeInSummary": true,
-              "required.message": "APPONE_ELIGIBILITYCHECKLIST_QUESTION_4_LABEL_REQUIRED_MESSAGE"
+              "required.message":
+                  "APPONE_ELIGIBILITYCHECKLIST_QUESTION_4_LABEL_REQUIRED_MESSAGE"
             }
           ],
-          "actionLabel": "APPONE_REGISTRATION_DELIVERYDETAILS_ACTION_BUTTON_LABEL_1",
+          "actionLabel":
+              "APPONE_REGISTRATION_DELIVERYDETAILS_ACTION_BUTTON_LABEL_1",
           "description": "APPONE_ELIGIBILITY_CHECKLIST_SCREEN_DESCRIPTION",
           "showTabView": false,
           "showAlertPopUp": {
@@ -4454,16 +4137,15 @@ final dynamic sampleSMCFlows = {
             "conditions": [
               {
                 "value": "To Administer",
-                "expression": "eligibilityChecklist.ec1==NO && eligibilityChecklist.ec3==NO && eligibilityChecklist.ec4==NO"
+                "expression":
+                    "eligibilityChecklist.ec1==NO && eligibilityChecklist.ec3==NO && eligibilityChecklist.ec4==NO"
               },
               {
                 "value": "Ineligible flow",
-                "expression": "eligibilityChecklist.ec1==NO && eligibilityChecklist.ec3==NO && eligibilityChecklist.ec4==YES"
+                "expression":
+                    "eligibilityChecklist.ec1==NO && eligibilityChecklist.ec3==NO && eligibilityChecklist.ec4==YES"
               },
-              {
-                "value": "referral flow",
-                "expression": "DEFAULT"
-              }
+              {"value": "referral flow", "expression": "DEFAULT"}
             ],
             "description": "APPONE_ELIGIBILITYCHECKLIST_ALERT_DESCRIPTION",
             "primaryActionLabel": "ACTION_SUBMIT",
@@ -4486,7 +4168,8 @@ final dynamic sampleSMCFlows = {
                 "data": [
                   {
                     "key": "selectedIndividualClientReferenceId",
-                    "value": "{{navigation.selectedIndividualClientReferenceId}}"
+                    "value":
+                        "{{navigation.selectedIndividualClientReferenceId}}"
                   },
                   {
                     "key": "selectedIndividualIdentifierId",
@@ -4498,7 +4181,8 @@ final dynamic sampleSMCFlows = {
                   },
                   {
                     "key": "ProjectBeneficiaryClientReferenceId",
-                    "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                    "value":
+                        "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                   }
                 ],
                 "name": "beneficiaryDetails",
@@ -4506,9 +4190,7 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {
-                      "message": "Navigation failed."
-                    }
+                    "properties": {"message": "Navigation failed."}
                   }
                 ],
                 "navigationMode": "popUntilAndPush",
@@ -4517,7 +4199,8 @@ final dynamic sampleSMCFlows = {
             }
           ],
           "condition": {
-            "expression": "eligibilityChecklist.ec1==NO && eligibilityChecklist.ec3==NO && eligibilityChecklist.ec4==NO"
+            "expression":
+                "eligibilityChecklist.ec1==NO && eligibilityChecklist.ec3==NO && eligibilityChecklist.ec4==NO"
           }
         },
         {
@@ -4528,7 +4211,8 @@ final dynamic sampleSMCFlows = {
                 "data": [
                   {
                     "key": "selectedIndividualClientReferenceId",
-                    "value": "{{navigation.selectedIndividualClientReferenceId}}"
+                    "value":
+                        "{{navigation.selectedIndividualClientReferenceId}}"
                   },
                   {
                     "key": "selectedIndividualIdentifierId",
@@ -4540,7 +4224,8 @@ final dynamic sampleSMCFlows = {
                   },
                   {
                     "key": "ProjectBeneficiaryClientReferenceId",
-                    "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                    "value":
+                        "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                   },
                   {
                     "key": "selectedIndividualName",
@@ -4554,19 +4239,14 @@ final dynamic sampleSMCFlows = {
                     "key": "selectedIndividualAgeInMonths",
                     "value": "{{navigation.selectedIndividualAgeInMonths}}"
                   },
-                  {
-                    "key": "cycleIndex",
-                    "value": "{{navigation.cycleIndex}}"
-                  }
+                  {"key": "cycleIndex", "value": "{{navigation.cycleIndex}}"}
                 ],
                 "name": "REFER_BENEFICIARY",
                 "type": "FORM",
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {
-                      "message": "Navigation failed."
-                    }
+                    "properties": {"message": "Navigation failed."}
                   }
                 ],
                 "navigationMode": "popUntilAndPush",
@@ -4575,7 +4255,8 @@ final dynamic sampleSMCFlows = {
             }
           ],
           "condition": {
-            "expression": "eligibilityChecklist.ec1==YES && eligibilityChecklist.ec3==YES && eligibilityChecklist.ec4==YES"
+            "expression":
+                "eligibilityChecklist.ec1==YES && eligibilityChecklist.ec3==YES && eligibilityChecklist.ec4==YES"
           }
         },
         {
@@ -4586,7 +4267,8 @@ final dynamic sampleSMCFlows = {
                 "data": [
                   {
                     "key": "selectedIndividualClientReferenceId",
-                    "value": "{{navigation.selectedIndividualClientReferenceId}}"
+                    "value":
+                        "{{navigation.selectedIndividualClientReferenceId}}"
                   },
                   {
                     "key": "selectedIndividualIdentifierId",
@@ -4598,15 +4280,14 @@ final dynamic sampleSMCFlows = {
                   },
                   {
                     "key": "ProjectBeneficiaryClientReferenceId",
-                    "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                    "value":
+                        "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                   }
                 ],
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {
-                      "message": "REGISTRATION_CHECKLIST_MESSAGE"
-                    }
+                    "properties": {"message": "REGISTRATION_CHECKLIST_MESSAGE"}
                   }
                 ],
                 "configName": "ineligibleConfig"
@@ -4619,9 +4300,7 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {
-                      "message": "Failed to create task records."
-                    }
+                    "properties": {"message": "Failed to create task records."}
                   }
                 ]
               }
@@ -4632,7 +4311,8 @@ final dynamic sampleSMCFlows = {
                 "data": [
                   {
                     "key": "selectedIndividualClientReferenceId",
-                    "value": "{{navigation.selectedIndividualClientReferenceId}}"
+                    "value":
+                        "{{navigation.selectedIndividualClientReferenceId}}"
                   },
                   {
                     "key": "selectedIndividualIdentifierId",
@@ -4644,7 +4324,8 @@ final dynamic sampleSMCFlows = {
                   },
                   {
                     "key": "ProjectBeneficiaryClientReferenceId",
-                    "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                    "value":
+                        "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                   }
                 ],
                 "name": "householdOverview",
@@ -4652,9 +4333,7 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {
-                      "message": "Navigation to flow failed."
-                    }
+                    "properties": {"message": "Navigation to flow failed."}
                   }
                 ],
                 "navigationMode": "popUntilAndPush",
@@ -4663,7 +4342,8 @@ final dynamic sampleSMCFlows = {
             }
           ],
           "condition": {
-            "expression": "eligibilityChecklist.ec1==NO && eligibilityChecklist.ec3==NO && eligibilityChecklist.ec4==YES"
+            "expression":
+                "eligibilityChecklist.ec1==NO && eligibilityChecklist.ec3==NO && eligibilityChecklist.ec4==YES"
           }
         },
         {
@@ -4674,7 +4354,8 @@ final dynamic sampleSMCFlows = {
                 "data": [
                   {
                     "key": "selectedIndividualClientReferenceId",
-                    "value": "{{navigation.selectedIndividualClientReferenceId}}"
+                    "value":
+                        "{{navigation.selectedIndividualClientReferenceId}}"
                   },
                   {
                     "key": "selectedIndividualIdentifierId",
@@ -4686,7 +4367,8 @@ final dynamic sampleSMCFlows = {
                   },
                   {
                     "key": "ProjectBeneficiaryClientReferenceId",
-                    "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                    "value":
+                        "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                   },
                   {
                     "key": "selectedIndividualName",
@@ -4700,19 +4382,14 @@ final dynamic sampleSMCFlows = {
                     "key": "selectedIndividualAgeInMonths",
                     "value": "{{navigation.selectedIndividualAgeInMonths}}"
                   },
-                  {
-                    "key": "cycleIndex",
-                    "value": "{{navigation.cycleIndex}}"
-                  }
+                  {"key": "cycleIndex", "value": "{{navigation.cycleIndex}}"}
                 ],
                 "name": "REFER_BENEFICIARY",
                 "type": "FORM",
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {
-                      "message": "Navigation failed."
-                    }
+                    "properties": {"message": "Navigation failed."}
                   }
                 ],
                 "navigationMode": "popUntilAndPush",
@@ -4720,9 +4397,7 @@ final dynamic sampleSMCFlows = {
               }
             }
           ],
-          "condition": {
-            "expression": "DEFAULT"
-          }
+          "condition": {"expression": "DEFAULT"}
         }
       ],
       "isSelected": true,
@@ -4740,11 +4415,13 @@ final dynamic sampleSMCFlows = {
           "flow": "ADD_MEMBER",
           "page": "beneficiaryDetails",
           "type": "object",
-          "label": "APPONE_REGISTRATION_BENEFICIARYDETAILS_SCREEN_HEADING_addmember",
+          "label":
+              "APPONE_REGISTRATION_BENEFICIARYDETAILS_SCREEN_HEADING_addmember",
           "order": 4,
           "footer": [
             {
-              "label": "APPONE_REGISTRATION_BENEFICIARYDETAILS_ACTION_BUTTON_LABEL_addmember",
+              "label":
+                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_ACTION_BUTTON_LABEL_addmember",
               "format": "button",
               "onAction": [
                 {
@@ -4770,7 +4447,8 @@ final dynamic sampleSMCFlows = {
             }
           ],
           "module": "REGISTRATION",
-          "heading": "APPONE_REGISTRATION_BENEFICIARYDETAILS_SCREEN_HEADING_addmember",
+          "heading":
+              "APPONE_REGISTRATION_BENEFICIARYDETAILS_SCREEN_HEADING_addmember",
           "summary": false,
           "version": 1,
           "onAction": [
@@ -4786,9 +4464,7 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {
-                      "message": "Failed to fetch config."
-                    }
+                    "properties": {"message": "Failed to fetch config."}
                   }
                 ],
                 "configName": "individualRegistration"
@@ -4803,10 +4479,7 @@ final dynamic sampleSMCFlows = {
                   }
                 }
               ],
-              "condition": {
-                "type": "custom",
-                "expression": "isEdit == true"
-              }
+              "condition": {"type": "custom", "expression": "isEdit == true"}
             },
             {
               "actions": [
@@ -4817,9 +4490,7 @@ final dynamic sampleSMCFlows = {
                   }
                 }
               ],
-              "condition": {
-                "expression": "DEFAULT"
-              }
+              "condition": {"expression": "DEFAULT"}
             },
             {
               "actionType": "NAVIGATION",
@@ -4835,9 +4506,7 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {
-                      "message": "Navigation failed."
-                    }
+                    "properties": {"message": "Navigation failed."}
                   }
                 ],
                 "navigationMode": "popUntilAndPush",
@@ -4858,14 +4527,16 @@ final dynamic sampleSMCFlows = {
           "properties": [
             {
               "type": "string",
-              "label": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_addmember",
+              "label":
+                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_addmember",
               "order": 1,
               "value": "",
               "format": "text",
               "hidden": false,
               "isMdms": false,
               "tooltip": "",
-              "helpText": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_helpText_addmember",
+              "helpText":
+                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_helpText_addmember",
               "infoText": "",
               "readOnly": false,
               "required": true,
@@ -4878,42 +4549,45 @@ final dynamic sampleSMCFlows = {
               "lengthRange": {
                 "maxLength": "200",
                 "minLength": "2",
-                "errorMessage": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_max_message_addmember"
+                "errorMessage":
+                    "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_max_message_addmember"
               },
               "validations": [
                 {
                   "type": "required",
                   "value": true,
-                  "message": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_mandatory_message_addmember"
+                  "message":
+                      "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_mandatory_message_addmember"
                 },
                 {
                   "type": "minLength",
                   "value": "2",
-                  "message": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_max_message_addmember"
+                  "message":
+                      "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_max_message_addmember"
                 },
                 {
                   "type": "maxLength",
                   "value": "200",
-                  "message": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_max_message_addmember"
+                  "message":
+                      "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_max_message_addmember"
                 }
               ],
               "errorMessage": "REGISTRATION_ADD_MEMBER_nameOfIndividual_ERROR",
               "isMultiSelect": false,
-              "required.message": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_mandatory_message_addmember"
+              "required.message":
+                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_mandatory_message_addmember"
             },
             {
               "type": "string",
               "enums": [
-                {
-                  "code": "DEFAULT",
-                  "name": "DEFAULT"
-                },
+                {"code": "DEFAULT", "name": "DEFAULT"},
                 {
                   "code": "UNIQUE_BENEFICIARY_ID",
                   "name": "UNIQUE_BENEFICIARY_ID"
                 }
               ],
-              "label": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_identifiers_addmember",
+              "label":
+                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_identifiers_addmember",
               "order": 3,
               "value": "",
               "format": "idPopulator",
@@ -4934,43 +4608,42 @@ final dynamic sampleSMCFlows = {
                 {
                   "type": "required",
                   "value": true,
-                  "message": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_idpopulator_mandatory_message_addmember"
+                  "message":
+                      "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_idpopulator_mandatory_message_addmember"
                 }
               ],
               "errorMessage": "REGISTRATION_ADD_MEMBER_identifiers_ERROR",
               "includeInForm": true,
               "isMultiSelect": false,
               "dropDownOptions": [
-                {
-                  "code": "DEFAULT",
-                  "name": "DEFAULT"
-                },
+                {"code": "DEFAULT", "name": "DEFAULT"},
                 {
                   "code": "UNIQUE_BENEFICIARY_ID",
                   "name": "UNIQUE_BENEFICIARY_ID"
                 },
-                {
-                  "code": "OTHER",
-                  "name": "OTHER"
-                }
+                {"code": "OTHER", "name": "OTHER"}
               ],
-              "required.message": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_idpopulator_mandatory_message_addmember"
+              "required.message":
+                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_idpopulator_mandatory_message_addmember"
             },
             {
               "type": "string",
-              "label": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_dobPicker_addmember",
+              "label":
+                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_dobPicker_addmember",
               "order": 4,
               "value": "",
               "format": "dob",
               "hidden": false,
               "isMdms": false,
-              "tooltip": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_dobPicker_tooltip_addmember",
+              "tooltip":
+                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_dobPicker_tooltip_addmember",
               "ageRange": {
                 "maxAge": 1800,
                 "minAge": 3,
                 "errorMessage": "AGE_VALIDATION_ADDMEMBER"
               },
-              "helpText": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_dobPicker_helpText_addmember",
+              "helpText":
+                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_dobPicker_helpText_addmember",
               "infoText": "",
               "readOnly": false,
               "required": true,
@@ -4984,7 +4657,8 @@ final dynamic sampleSMCFlows = {
                 {
                   "type": "required",
                   "value": true,
-                  "message": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_dobPicker_mandatory_message_addmember"
+                  "message":
+                      "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_dobPicker_mandatory_message_addmember"
                 },
                 {
                   "type": "minAge",
@@ -4999,21 +4673,17 @@ final dynamic sampleSMCFlows = {
               ],
               "errorMessage": "REGISTRATION_ADD_MEMBER_dobPicker_ERROR",
               "isMultiSelect": false,
-              "required.message": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_dobPicker_mandatory_message_addmember"
+              "required.message":
+                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_dobPicker_mandatory_message_addmember"
             },
             {
               "type": "string",
               "enums": [
-                {
-                  "code": "MALE",
-                  "name": "MALE"
-                },
-                {
-                  "code": "FEMALE",
-                  "name": "FEMALE"
-                }
+                {"code": "MALE", "name": "MALE"},
+                {"code": "FEMALE", "name": "FEMALE"}
               ],
-              "label": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_gender_addmember",
+              "label":
+                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_gender_addmember",
               "order": 5,
               "value": "",
               "format": "select",
@@ -5040,20 +4710,15 @@ final dynamic sampleSMCFlows = {
               "errorMessage": "REGISTRATION_ADD_MEMBER_gender_ERROR",
               "isMultiSelect": false,
               "dropDownOptions": [
-                {
-                  "code": "MALE",
-                  "name": "MALE"
-                },
-                {
-                  "code": "FEMALE",
-                  "name": "FEMALE"
-                }
+                {"code": "MALE", "name": "MALE"},
+                {"code": "FEMALE", "name": "FEMALE"}
               ],
               "required.message": "GENDER_MANDATORY_MESSAGE_ADDMEMBER"
             },
             {
               "type": "integer",
-              "label": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_height_addmember",
+              "label":
+                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_height_addmember",
               "order": 6,
               "value": "",
               "format": "text",
@@ -5076,12 +4741,14 @@ final dynamic sampleSMCFlows = {
                 {
                   "type": "min",
                   "value": true,
-                  "message": "APPONE_REGISTRATION_HOUSEDETAILS_label_height_Min_message_addmember"
+                  "message":
+                      "APPONE_REGISTRATION_HOUSEDETAILS_label_height_Min_message_addmember"
                 },
                 {
                   "type": "max",
                   "value": true,
-                  "message": "APPONE_REGISTRATION_HOUSEDETAILS_label_height_Max_message_addmember"
+                  "message":
+                      "APPONE_REGISTRATION_HOUSEDETAILS_label_height_Max_message_addmember"
                 }
               ],
               "errorMessage": "REGISTRATION_ADD_MEMBER_height_ERROR",
@@ -5089,7 +4756,8 @@ final dynamic sampleSMCFlows = {
             },
             {
               "type": "integer",
-              "label": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_weight_addmember",
+              "label":
+                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_weight_addmember",
               "order": 7,
               "value": "",
               "format": "text",
@@ -5114,16 +4782,49 @@ final dynamic sampleSMCFlows = {
               "isMultiSelect": false
             },
             {
-              "type": "string",
-              "label": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_phone_addmember",
+              "type": "boolean",
+              "label":
+                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_isPregnant_addmember",
               "order": 8,
+              "value": "",
+              "format": "checkbox",
+              "hidden": false,
+              "tooltip": "",
+              "helpText": "",
+              "infoText": "",
+              "readOnly": false,
+              "fieldName": "isPregnant",
+              "mandatory": false,
+              "showLabel": false,
+              "deleteFlag": false,
+              "innerLabel": "",
+              "systemDate": false,
+              "validations": [],
+              "errorMessage": "",
+              "isMultiSelect": false,
+              "visibilityCondition": {
+                "expression": [
+                  {
+                    "condition":
+                        "beneficiaryDetails.gender==FEMALE && calculateAgeInMonths(beneficiaryDetails.dobPicker)>=180"
+                  }
+                ]
+              }
+            },
+            {
+              "type": "string",
+              "label":
+                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_phone_addmember",
+              "order": 9,
               "value": "",
               "format": "mobileNumber",
               "hidden": false,
               "isMdms": false,
               "pattern": "^\\d+",
-              "tooltip": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_phone_tooltip_addmember",
-              "helpText": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_phone_helpText_addmember",
+              "tooltip":
+                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_phone_tooltip_addmember",
+              "helpText":
+                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_phone_helpText_addmember",
               "infoText": "",
               "readOnly": false,
               "fieldName": "phone",
@@ -5160,8 +4861,9 @@ final dynamic sampleSMCFlows = {
             },
             {
               "type": "string",
-              "label": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_scanner_addmember",
-              "order": 7,
+              "label":
+                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_scanner_addmember",
+              "order": 10,
               "value": "",
               "format": "scanner",
               "hidden": false,
@@ -5190,8 +4892,10 @@ final dynamic sampleSMCFlows = {
               "includeInSummary": true
             }
           ],
-          "actionLabel": "APPONE_REGISTRATION_BENEFICIARYDETAILS_ACTION_BUTTON_LABEL_addmember",
-          "description": "APPONE_REGISTRATION_BENEFICIARYDETAILS_SCREEN_DESCRIPTION_addmember",
+          "actionLabel":
+              "APPONE_REGISTRATION_BENEFICIARYDETAILS_ACTION_BUTTON_LABEL_addmember",
+          "description":
+              "APPONE_REGISTRATION_BENEFICIARYDETAILS_SCREEN_DESCRIPTION_addmember",
           "showTabView": false,
           "submitCondition": null,
           "preventScreenCapture": false,
@@ -5215,9 +4919,7 @@ final dynamic sampleSMCFlows = {
             "onError": [
               {
                 "actionType": "SHOW_TOAST",
-                "properties": {
-                  "message": "REGISTRATION_ADD_MEMBER_MESSAGE"
-                }
+                "properties": {"message": "REGISTRATION_ADD_MEMBER_MESSAGE"}
               }
             ],
             "configName": "individualRegistration"
@@ -5232,10 +4934,7 @@ final dynamic sampleSMCFlows = {
               }
             }
           ],
-          "condition": {
-            "type": "custom",
-            "expression": "isEdit == true"
-          }
+          "condition": {"type": "custom", "expression": "isEdit == true"}
         },
         {
           "actions": [
@@ -5255,14 +4954,10 @@ final dynamic sampleSMCFlows = {
             },
             {
               "actionType": "CREATE_EVENT",
-              "properties": {
-                "entity": "INDIVIDUAL, PROJECTBENEFICIARY, MEMBER"
-              }
+              "properties": {"entity": "INDIVIDUAL, PROJECTBENEFICIARY, MEMBER"}
             }
           ],
-          "condition": {
-            "expression": "DEFAULT"
-          }
+          "condition": {"expression": "DEFAULT"}
         },
         {
           "actionType": "NAVIGATION",
@@ -5278,9 +4973,7 @@ final dynamic sampleSMCFlows = {
             "onError": [
               {
                 "actionType": "SHOW_TOAST",
-                "properties": {
-                  "message": "Navigation failed."
-                }
+                "properties": {"message": "Navigation failed."}
               }
             ],
             "navigationMode": "popUntilAndPush",
@@ -5293,10 +4986,7 @@ final dynamic sampleSMCFlows = {
       "initActions": [],
       "wrapperConfig": {
         "filters": [
-          {
-            "field": "isHeadOfHousehold",
-            "equals": true
-          }
+          {"field": "isHeadOfHousehold", "equals": true}
         ],
         "relations": [
           {
@@ -5397,10 +5087,7 @@ final dynamic sampleSMCFlows = {
               "onAction": [
                 {
                   "actionType": "NAVIGATION",
-                  "properties": {
-                    "name": "acknowledgement",
-                    "type": "screen"
-                  }
+                  "properties": {"name": "acknowledgement", "type": "screen"}
                 }
               ],
               "properties": {
@@ -5422,7 +5109,8 @@ final dynamic sampleSMCFlows = {
                 "data": [
                   {
                     "key": "selectedIndividualClientReferenceId",
-                    "value": "{{navigation.selectedIndividualClientReferenceId}}"
+                    "value":
+                        "{{navigation.selectedIndividualClientReferenceId}}"
                   },
                   {
                     "key": "selectedIndividualIdentifierId",
@@ -5434,7 +5122,8 @@ final dynamic sampleSMCFlows = {
                   },
                   {
                     "key": "ProjectBeneficiaryClientReferenceId",
-                    "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                    "value":
+                        "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                   },
                   {
                     "key": "selectedIndividualName",
@@ -5470,7 +5159,8 @@ final dynamic sampleSMCFlows = {
                 "data": [
                   {
                     "key": "selectedIndividualClientReferenceId",
-                    "value": "{{navigation.selectedIndividualClientReferenceId}}"
+                    "value":
+                        "{{navigation.selectedIndividualClientReferenceId}}"
                   },
                   {
                     "key": "selectedIndividualIdentifierId",
@@ -5482,7 +5172,8 @@ final dynamic sampleSMCFlows = {
                   },
                   {
                     "key": "ProjectBeneficiaryClientReferenceId",
-                    "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                    "value":
+                        "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                   },
                   {
                     "key": "selectedIndividualName",
@@ -5496,18 +5187,13 @@ final dynamic sampleSMCFlows = {
                     "key": "selectedIndividualAgeInMonths",
                     "value": "{{navigation.selectedIndividualAgeInMonths}}"
                   },
-                  {
-                    "key": "cycleIndex",
-                    "value": "{{navigation.cycleIndex}}"
-                  }
+                  {"key": "cycleIndex", "value": "{{navigation.cycleIndex}}"}
                 ],
                 "entity": "HFREFERRAL",
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {
-                      "message": "Failed to create HFReferral."
-                    }
+                    "properties": {"message": "Failed to create HFReferral."}
                   }
                 ]
               }
@@ -5518,7 +5204,8 @@ final dynamic sampleSMCFlows = {
                 "data": [
                   {
                     "key": "selectedIndividualClientReferenceId",
-                    "value": "{{navigation.selectedIndividualClientReferenceId}}"
+                    "value":
+                        "{{navigation.selectedIndividualClientReferenceId}}"
                   },
                   {
                     "key": "selectedIndividualIdentifierId",
@@ -5530,7 +5217,8 @@ final dynamic sampleSMCFlows = {
                   },
                   {
                     "key": "ProjectBeneficiaryClientReferenceId",
-                    "value": "{{navigation.ProjectBeneficiaryClientReferenceId}}"
+                    "value":
+                        "{{navigation.ProjectBeneficiaryClientReferenceId}}"
                   },
                   {
                     "key": "selectedIndividualName",
@@ -5544,10 +5232,7 @@ final dynamic sampleSMCFlows = {
                     "key": "selectedIndividualAgeInMonths",
                     "value": "{{navigation.selectedIndividualAgeInMonths}}"
                   },
-                  {
-                    "key": "cycleIndex",
-                    "value": "{{navigation.cycleIndex}}"
-                  }
+                  {"key": "cycleIndex", "value": "{{navigation.cycleIndex}}"}
                 ],
                 "name": "referralSuccess",
                 "type": "TEMPLATE",
@@ -5564,10 +5249,7 @@ final dynamic sampleSMCFlows = {
               }
             }
           ],
-          "navigateTo": {
-            "name": "acknowledgement",
-            "type": "screen"
-          },
+          "navigateTo": {"name": "acknowledgement", "type": "screen"},
           "properties": [
             {
               "type": "string",
@@ -5595,8 +5277,10 @@ final dynamic sampleSMCFlows = {
                   "message": "REFER_BENEFICIARY_ADMINISTRATIVE_UNIT_REQUIRED"
                 }
               ],
-              "errorMessage": "REGISTRATION_REFER_BENEFICIARY_administrativeArea_ERROR",
-              "required.message": "REFER_BENEFICIARY_ADMINISTRATIVE_UNIT_REQUIRED"
+              "errorMessage":
+                  "REGISTRATION_REFER_BENEFICIARY_administrativeArea_ERROR",
+              "required.message":
+                  "REFER_BENEFICIARY_ADMINISTRATIVE_UNIT_REQUIRED"
             },
             {
               "type": "string",
@@ -5627,10 +5311,7 @@ final dynamic sampleSMCFlows = {
               "errorMessage": "REGISTRATION_REFER_BENEFICIARY_referredBy_ERROR",
               "required.message": "REFER_BENEFICIARY_REFERRED_BY_REQUIRED",
               "autoFillCondition": [
-                {
-                  "value": "{{loggedInUserUuid}}",
-                  "expression": "true==true"
-                }
+                {"value": "{{loggedInUserUuid}}", "expression": "true==true"}
               ]
             },
             {
@@ -5660,18 +5341,17 @@ final dynamic sampleSMCFlows = {
                   "message": "REFER_BENEFICIARY_ADMINISTRATIVE_UNIT_REQUIRED"
                 }
               ],
-              "errorMessage": "REGISTRATION_REFER_BENEFICIARY_healthFacility_ERROR",
+              "errorMessage":
+                  "REGISTRATION_REFER_BENEFICIARY_healthFacility_ERROR",
               "includeInForm": true,
               "isMultiSelect": false,
-              "required.message": "REFER_BENEFICIARY_ADMINISTRATIVE_UNIT_REQUIRED"
+              "required.message":
+                  "REFER_BENEFICIARY_ADMINISTRATIVE_UNIT_REQUIRED"
             },
             {
               "type": "string",
               "enums": [
-                {
-                  "code": "FEVER",
-                  "name": "FEVER"
-                }
+                {"code": "FEVER", "name": "FEVER"}
               ],
               "label": "HFREFERRAL_REFERRAL_DETAILS_referralReason_LABEL",
               "order": 4,
@@ -5694,12 +5374,15 @@ final dynamic sampleSMCFlows = {
                 {
                   "type": "required",
                   "value": true,
-                  "message": "HFREFERRAL_REFERRAL_DETAILS_referralReason_REQUIRED_ERROR"
+                  "message":
+                      "HFREFERRAL_REFERRAL_DETAILS_referralReason_REQUIRED_ERROR"
                 }
               ],
-              "errorMessage": "REGISTRATION_REFER_BENEFICIARY_referralReason_ERROR",
+              "errorMessage":
+                  "REGISTRATION_REFER_BENEFICIARY_referralReason_ERROR",
               "isMultiSelect": false,
-              "required.message": "HFREFERRAL_REFERRAL_DETAILS_referralReason_REQUIRED_ERROR"
+              "required.message":
+                  "HFREFERRAL_REFERRAL_DETAILS_referralReason_REQUIRED_ERROR"
             }
           ],
           "actionLabel": "REFER_BENEFICIARY_SUBMIT_BUTTON",
@@ -5747,17 +5430,12 @@ final dynamic sampleSMCFlows = {
                 "key": "selectedIndividualAgeInMonths",
                 "value": "{{navigation.selectedIndividualAgeInMonths}}"
               },
-              {
-                "key": "cycleIndex",
-                "value": "{{fn:getCurrentCycleIndex()}}"
-              }
+              {"key": "cycleIndex", "value": "{{fn:getCurrentCycleIndex()}}"}
             ],
             "onError": [
               {
                 "actionType": "SHOW_TOAST",
-                "properties": {
-                  "message": "Failed to fetch config."
-                }
+                "properties": {"message": "Failed to fetch config."}
               }
             ],
             "configName": "referralBeneficaryCreate"
@@ -5795,18 +5473,13 @@ final dynamic sampleSMCFlows = {
                 "key": "selectedIndividualAgeInMonths",
                 "value": "{{navigation.selectedIndividualAgeInMonths}}"
               },
-              {
-                "key": "cycleIndex",
-                "value": "{{navigation.cycleIndex}}"
-              }
+              {"key": "cycleIndex", "value": "{{navigation.cycleIndex}}"}
             ],
             "entity": "HFREFERRAL",
             "onError": [
               {
                 "actionType": "SHOW_TOAST",
-                "properties": {
-                  "message": "Failed to create HFReferral."
-                }
+                "properties": {"message": "Failed to create HFReferral."}
               }
             ]
           }
@@ -5843,19 +5516,14 @@ final dynamic sampleSMCFlows = {
                 "key": "selectedIndividualAgeInMonths",
                 "value": "{{navigation.selectedIndividualAgeInMonths}}"
               },
-              {
-                "key": "cycleIndex",
-                "value": "{{navigation.cycleIndex}}"
-              }
+              {"key": "cycleIndex", "value": "{{navigation.cycleIndex}}"}
             ],
             "name": "referralSuccess",
             "type": "TEMPLATE",
             "onError": [
               {
                 "actionType": "SHOW_TOAST",
-                "properties": {
-                  "message": "Navigation failed."
-                }
+                "properties": {"message": "Navigation failed."}
               }
             ],
             "navigationMode": "popUntilAndPush",
@@ -5882,7 +5550,8 @@ final dynamic sampleSMCFlows = {
           "order": 4,
           "footer": [
             {
-              "label": "APPONE_REGISTRATION_BENEFICIARYDETAILS_ACTION_BUTTON_LABEL_1",
+              "label":
+                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_ACTION_BUTTON_LABEL_1",
               "format": "button",
               "onAction": [
                 {
@@ -5920,9 +5589,7 @@ final dynamic sampleSMCFlows = {
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {
-                          "message": "Failed to fetch config."
-                        }
+                        "properties": {"message": "Failed to fetch config."}
                       }
                     ],
                     "configName": "beneficiaryRegistration"
@@ -5933,10 +5600,7 @@ final dynamic sampleSMCFlows = {
                   "properties": {
                     "entity": "HouseholdModel, TaskModel",
                     "modify": [
-                      {
-                        "key": "TaskModel.status",
-                        "value": "NOT_ADMINISTERED"
-                      }
+                      {"key": "TaskModel.status", "value": "NOT_ADMINISTERED"}
                     ],
                     "onError": [
                       {
@@ -5954,7 +5618,8 @@ final dynamic sampleSMCFlows = {
                     "data": [
                       {
                         "key": "HouseholdClientReferenceId",
-                        "value": "{{contextData.entities.HouseholdModel.clientReferenceId}}"
+                        "value":
+                            "{{contextData.entities.HouseholdModel.clientReferenceId}}"
                       }
                     ],
                     "name": "householdOverview",
@@ -5962,9 +5627,7 @@ final dynamic sampleSMCFlows = {
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {
-                          "message": "Navigation failed."
-                        }
+                        "properties": {"message": "Navigation failed."}
                       }
                     ],
                     "navigationMode": "popUntilAndPush",
@@ -5985,9 +5648,7 @@ final dynamic sampleSMCFlows = {
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {
-                          "message": "Failed to fetch config."
-                        }
+                        "properties": {"message": "Failed to fetch config."}
                       }
                     ],
                     "configName": "beneficiaryRegistration"
@@ -6000,9 +5661,7 @@ final dynamic sampleSMCFlows = {
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {
-                          "message": "Failed to update household."
-                        }
+                        "properties": {"message": "Failed to update household."}
                       }
                     ]
                   }
@@ -6013,7 +5672,8 @@ final dynamic sampleSMCFlows = {
                     "data": [
                       {
                         "key": "HouseholdClientReferenceId",
-                        "value": "{{contextData.entities.HouseholdModel.clientReferenceId}}"
+                        "value":
+                            "{{contextData.entities.HouseholdModel.clientReferenceId}}"
                       }
                     ],
                     "name": "householdOverview",
@@ -6021,9 +5681,7 @@ final dynamic sampleSMCFlows = {
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {
-                          "message": "Navigation failed."
-                        }
+                        "properties": {"message": "Navigation failed."}
                       }
                     ],
                     "navigationMode": "popUntilAndPush",
@@ -6031,10 +5689,7 @@ final dynamic sampleSMCFlows = {
                   }
                 }
               ],
-              "condition": {
-                "type": "custom",
-                "expression": "isEdit==true"
-              }
+              "condition": {"type": "custom", "expression": "isEdit==true"}
             },
             {
               "actions": [
@@ -6044,9 +5699,7 @@ final dynamic sampleSMCFlows = {
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {
-                          "message": "Failed to fetch config."
-                        }
+                        "properties": {"message": "Failed to fetch config."}
                       }
                     ],
                     "configName": "beneficiaryRegistration"
@@ -6055,13 +5708,12 @@ final dynamic sampleSMCFlows = {
                 {
                   "actionType": "CREATE_EVENT",
                   "properties": {
-                    "entity": "HOUSEHOLD, INDIVIDUAL, PROJECTBENEFICIARY, MEMBER",
+                    "entity":
+                        "HOUSEHOLD, INDIVIDUAL, PROJECTBENEFICIARY, MEMBER",
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {
-                          "message": "Failed to create household."
-                        }
+                        "properties": {"message": "Failed to create household."}
                       }
                     ]
                   }
@@ -6072,7 +5724,8 @@ final dynamic sampleSMCFlows = {
                     "data": [
                       {
                         "key": "HouseholdClientReferenceId",
-                        "value": "{{contextData.entities.HouseholdModel.clientReferenceId}}"
+                        "value":
+                            "{{contextData.entities.HouseholdModel.clientReferenceId}}"
                       }
                     ],
                     "name": "householdOverview",
@@ -6080,9 +5733,7 @@ final dynamic sampleSMCFlows = {
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {
-                          "message": "Navigation failed."
-                        }
+                        "properties": {"message": "Navigation failed."}
                       }
                     ],
                     "navigationMode": "popUntilAndPush",
@@ -6090,9 +5741,7 @@ final dynamic sampleSMCFlows = {
                   }
                 }
               ],
-              "condition": {
-                "expression": "DEFAULT"
-              }
+              "condition": {"expression": "DEFAULT"}
             }
           ],
           "navigateTo": {
@@ -6108,14 +5757,16 @@ final dynamic sampleSMCFlows = {
           "properties": [
             {
               "type": "string",
-              "label": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual",
+              "label":
+                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual",
               "order": 1,
               "value": "",
               "format": "text",
               "hidden": false,
               "isMdms": false,
               "tooltip": "",
-              "helpText": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_helpText",
+              "helpText":
+                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_helpText",
               "infoText": "",
               "readOnly": false,
               "required": true,
@@ -6128,32 +5779,38 @@ final dynamic sampleSMCFlows = {
               "lengthRange": {
                 "maxLength": "200",
                 "minLength": "2",
-                "errorMessage": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_max_message"
+                "errorMessage":
+                    "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_max_message"
               },
               "validations": [
                 {
                   "type": "required",
                   "value": true,
-                  "message": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_mandatory_message"
+                  "message":
+                      "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_mandatory_message"
                 },
                 {
                   "type": "minLength",
                   "value": "2",
-                  "message": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_max_message"
+                  "message":
+                      "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_max_message"
                 },
                 {
                   "type": "maxLength",
                   "value": "200",
-                  "message": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_max_message"
+                  "message":
+                      "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_max_message"
                 }
               ],
               "errorMessage": "REGISTRATION_HOUSEHOLD_nameOfIndividual_ERROR",
               "isMultiSelect": false,
-              "required.message": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_mandatory_message"
+              "required.message":
+                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_nameOfIndividual_mandatory_message"
             },
             {
               "type": "boolean",
-              "label": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_isHeadOfFamily",
+              "label":
+                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_isHeadOfFamily",
               "order": 3,
               "value": "",
               "format": "checkbox",
@@ -6175,26 +5832,26 @@ final dynamic sampleSMCFlows = {
                 {
                   "type": "required",
                   "value": true,
-                  "message": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_isHeadOfFamily_mandatory_message"
+                  "message":
+                      "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_isHeadOfFamily_mandatory_message"
                 }
               ],
               "errorMessage": "REGISTRATION_HOUSEHOLD_isHeadOfFamily_ERROR",
               "isMultiSelect": false,
-              "required.message": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_isHeadOfFamily_mandatory_message"
+              "required.message":
+                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_isHeadOfFamily_mandatory_message"
             },
             {
               "type": "string",
               "enums": [
-                {
-                  "code": "DEFAULT",
-                  "name": "DEFAULT"
-                },
+                {"code": "DEFAULT", "name": "DEFAULT"},
                 {
                   "code": "UNIQUE_BENEFICIARY_ID",
                   "name": "UNIQUE_BENEFICIARY_ID"
                 }
               ],
-              "label": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_identifiers",
+              "label":
+                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_identifiers",
               "order": 4,
               "value": "",
               "format": "idPopulator",
@@ -6215,12 +5872,14 @@ final dynamic sampleSMCFlows = {
                 {
                   "type": "required",
                   "value": true,
-                  "message": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_idpopulator_mandatory_message"
+                  "message":
+                      "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_idpopulator_mandatory_message"
                 }
               ],
               "errorMessage": "REGISTRATION_HOUSEHOLD_identifiers_ERROR",
               "isMultiSelect": false,
-              "required.message": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_idpopulator_mandatory_message"
+              "required.message":
+                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_idpopulator_mandatory_message"
             },
             {
               "type": "string",
@@ -6230,13 +5889,15 @@ final dynamic sampleSMCFlows = {
               "format": "dob",
               "hidden": false,
               "isMdms": false,
-              "tooltip": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_dobPicker_tooltip",
+              "tooltip":
+                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_dobPicker_tooltip",
               "ageRange": {
                 "maxAge": 1800,
                 "minAge": 3,
                 "errorMessage": "AGE_VALIDATION"
               },
-              "helpText": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_dobPicker_helpText",
+              "helpText":
+                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_dobPicker_helpText",
               "infoText": "",
               "readOnly": false,
               "required": true,
@@ -6250,34 +5911,22 @@ final dynamic sampleSMCFlows = {
                 {
                   "type": "required",
                   "value": true,
-                  "message": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_dobPicker_mandatory_message"
+                  "message":
+                      "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_dobPicker_mandatory_message"
                 },
-                {
-                  "type": "minAge",
-                  "value": 3,
-                  "message": "AGE_VALIDATION"
-                },
-                {
-                  "type": "maxAge",
-                  "value": 1800,
-                  "message": "AGE_VALIDATION"
-                }
+                {"type": "minAge", "value": 3, "message": "AGE_VALIDATION"},
+                {"type": "maxAge", "value": 1800, "message": "AGE_VALIDATION"}
               ],
               "errorMessage": "REGISTRATION_HOUSEHOLD_dobPicker_ERROR",
               "isMultiSelect": false,
-              "required.message": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_dobPicker_mandatory_message"
+              "required.message":
+                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_dobPicker_mandatory_message"
             },
             {
               "type": "string",
               "enums": [
-                {
-                  "code": "MALE",
-                  "name": "MALE"
-                },
-                {
-                  "code": "FEMALE",
-                  "name": "FEMALE"
-                }
+                {"code": "MALE", "name": "MALE"},
+                {"code": "FEMALE", "name": "FEMALE"}
               ],
               "label": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_gender",
               "order": 6,
@@ -6327,17 +5976,20 @@ final dynamic sampleSMCFlows = {
                 {
                   "type": "required",
                   "value": true,
-                  "message": "APPONE_REGISTRATION_HOUSEDETAILS_label_height_IS_MANDATORY"
+                  "message":
+                      "APPONE_REGISTRATION_HOUSEDETAILS_label_height_IS_MANDATORY"
                 },
                 {
                   "type": "min",
                   "value": true,
-                  "message": "APPONE_REGISTRATION_HOUSEDETAILS_label_height_Min_message"
+                  "message":
+                      "APPONE_REGISTRATION_HOUSEDETAILS_label_height_Min_message"
                 },
                 {
                   "type": "max",
                   "value": true,
-                  "message": "APPONE_REGISTRATION_HOUSEDETAILS_label_height_Max_message"
+                  "message":
+                      "APPONE_REGISTRATION_HOUSEDETAILS_label_height_Max_message"
                 }
               ],
               "errorMessage": "REGISTRATION_HOUSEHOLD_height_ERROR",
@@ -6363,23 +6015,56 @@ final dynamic sampleSMCFlows = {
                 {
                   "type": "required",
                   "value": true,
-                  "message": "APPONE_REGISTRATION_HOUSEDETAILS_label_weight_IS_MANDATORY"
+                  "message":
+                      "APPONE_REGISTRATION_HOUSEDETAILS_label_weight_IS_MANDATORY"
                 }
               ],
               "errorMessage": "REGISTRATION_HOUSEHOLD_weight_ERROR",
               "isMultiSelect": false
             },
             {
+              "type": "boolean",
+              "label":
+                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_isPregnant",
+              "order": 9,
+              "value": "",
+              "format": "checkbox",
+              "hidden": false,
+              "tooltip": "",
+              "helpText": "",
+              "infoText": "",
+              "readOnly": false,
+              "fieldName": "isPregnant",
+              "mandatory": false,
+              "showLabel": false,
+              "deleteFlag": false,
+              "innerLabel": "",
+              "systemDate": false,
+              "validations": [],
+              "errorMessage": "",
+              "isMultiSelect": false,
+              "visibilityCondition": {
+                "expression": [
+                  {
+                    "condition":
+                        "beneficiaryDetails.gender==FEMALE && calculateAgeInMonths(beneficiaryDetails.dobPicker)>=180"
+                  }
+                ]
+              }
+            },
+            {
               "type": "string",
               "label": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_phone",
-              "order": 9,
+              "order": 10,
               "value": "",
               "format": "mobileNumber",
               "hidden": false,
               "isMdms": false,
               "pattern": "^\\d+",
-              "tooltip": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_phone_tooltip",
-              "helpText": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_phone_helpText",
+              "tooltip":
+                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_phone_tooltip",
+              "helpText":
+                  "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_phone_helpText",
               "infoText": "",
               "readOnly": false,
               "fieldName": "phone",
@@ -6417,7 +6102,7 @@ final dynamic sampleSMCFlows = {
             {
               "type": "string",
               "label": "APPONE_REGISTRATION_BENEFICIARYDETAILS_label_scanner",
-              "order": 10,
+              "order": 11,
               "value": "",
               "format": "scanner",
               "hidden": false,
@@ -6446,8 +6131,10 @@ final dynamic sampleSMCFlows = {
               "includeInSummary": true
             }
           ],
-          "actionLabel": "APPONE_REGISTRATION_BENEFICIARYDETAILS_ACTION_BUTTON_LABEL_1",
-          "description": "APPONE_REGISTRATION_BENEFICIARYDETAILS_SCREEN_DESCRIPTION",
+          "actionLabel":
+              "APPONE_REGISTRATION_BENEFICIARYDETAILS_ACTION_BUTTON_LABEL_1",
+          "description":
+              "APPONE_REGISTRATION_BENEFICIARYDETAILS_SCREEN_DESCRIPTION",
           "showTabView": false,
           "submitCondition": null,
           "preventScreenCapture": false,
@@ -6462,15 +6149,13 @@ final dynamic sampleSMCFlows = {
           "order": 3,
           "footer": [
             {
-              "label": "APPONE_REGISTRATION_HOUSEHOLDDETAILS_ACTION_BUTTON_LABEL_1",
+              "label":
+                  "APPONE_REGISTRATION_HOUSEHOLDDETAILS_ACTION_BUTTON_LABEL_1",
               "format": "button",
               "onAction": [
                 {
                   "actionType": "NAVIGATION",
-                  "properties": {
-                    "name": "beneficiaryDetails",
-                    "type": "form"
-                  }
+                  "properties": {"name": "beneficiaryDetails", "type": "form"}
                 }
               ],
               "properties": {
@@ -6507,10 +6192,7 @@ final dynamic sampleSMCFlows = {
                   "properties": {
                     "entity": "HouseholdModel, TaskModel",
                     "modify": [
-                      {
-                        "key": "TaskModel.status",
-                        "value": "NOT_ADMINISTERED"
-                      }
+                      {"key": "TaskModel.status", "value": "NOT_ADMINISTERED"}
                     ],
                     "onError": [
                       {
@@ -6528,7 +6210,8 @@ final dynamic sampleSMCFlows = {
                     "data": [
                       {
                         "key": "HouseholdClientReferenceId",
-                        "value": "{{contextData.entities.HouseholdModel.clientReferenceId}}"
+                        "value":
+                            "{{contextData.entities.HouseholdModel.clientReferenceId}}"
                       }
                     ],
                     "name": "householdOverview",
@@ -6536,9 +6219,7 @@ final dynamic sampleSMCFlows = {
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {
-                          "message": "Navigation failed."
-                        }
+                        "properties": {"message": "Navigation failed."}
                       }
                     ],
                     "navigationMode": "popUntilAndPush",
@@ -6559,9 +6240,7 @@ final dynamic sampleSMCFlows = {
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {
-                          "message": "Failed to fetch config."
-                        }
+                        "properties": {"message": "Failed to fetch config."}
                       }
                     ],
                     "configName": "beneficiaryRegistration"
@@ -6574,9 +6253,7 @@ final dynamic sampleSMCFlows = {
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {
-                          "message": "Failed to update household."
-                        }
+                        "properties": {"message": "Failed to update household."}
                       }
                     ]
                   }
@@ -6587,7 +6264,8 @@ final dynamic sampleSMCFlows = {
                     "data": [
                       {
                         "key": "HouseholdClientReferenceId",
-                        "value": "{{contextData.entities.HouseholdModel.clientReferenceId}}"
+                        "value":
+                            "{{contextData.entities.HouseholdModel.clientReferenceId}}"
                       }
                     ],
                     "name": "householdOverview",
@@ -6595,9 +6273,7 @@ final dynamic sampleSMCFlows = {
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {
-                          "message": "Navigation failed."
-                        }
+                        "properties": {"message": "Navigation failed."}
                       }
                     ],
                     "navigationMode": "popUntilAndPush",
@@ -6605,10 +6281,7 @@ final dynamic sampleSMCFlows = {
                   }
                 }
               ],
-              "condition": {
-                "type": "custom",
-                "expression": "isEdit==true"
-              }
+              "condition": {"type": "custom", "expression": "isEdit==true"}
             },
             {
               "actions": [
@@ -6618,9 +6291,7 @@ final dynamic sampleSMCFlows = {
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {
-                          "message": "Failed to fetch config."
-                        }
+                        "properties": {"message": "Failed to fetch config."}
                       }
                     ],
                     "configName": "beneficiaryRegistration"
@@ -6629,13 +6300,12 @@ final dynamic sampleSMCFlows = {
                 {
                   "actionType": "CREATE_EVENT",
                   "properties": {
-                    "entity": "HOUSEHOLD, INDIVIDUAL, PROJECTBENEFICIARY, MEMBER",
+                    "entity":
+                        "HOUSEHOLD, INDIVIDUAL, PROJECTBENEFICIARY, MEMBER",
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {
-                          "message": "Failed to create household."
-                        }
+                        "properties": {"message": "Failed to create household."}
                       }
                     ]
                   }
@@ -6646,7 +6316,8 @@ final dynamic sampleSMCFlows = {
                     "data": [
                       {
                         "key": "HouseholdClientReferenceId",
-                        "value": "{{contextData.entities.HouseholdModel.clientReferenceId}}"
+                        "value":
+                            "{{contextData.entities.HouseholdModel.clientReferenceId}}"
                       }
                     ],
                     "name": "householdOverview",
@@ -6654,9 +6325,7 @@ final dynamic sampleSMCFlows = {
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {
-                          "message": "Navigation failed."
-                        }
+                        "properties": {"message": "Navigation failed."}
                       }
                     ],
                     "navigationMode": "popUntilAndPush",
@@ -6664,19 +6333,15 @@ final dynamic sampleSMCFlows = {
                   }
                 }
               ],
-              "condition": {
-                "expression": "DEFAULT"
-              }
+              "condition": {"expression": "DEFAULT"}
             }
           ],
-          "navigateTo": {
-            "name": "beneficiaryDetails",
-            "type": "form"
-          },
+          "navigateTo": {"name": "beneficiaryDetails", "type": "form"},
           "properties": [
             {
               "type": "string",
-              "label": "APPONE_REGISTRATION_HOUSEHOLDDETAILS_label_dateOfRegistration",
+              "label":
+                  "APPONE_REGISTRATION_HOUSEHOLDDETAILS_label_dateOfRegistration",
               "order": 1,
               "value": "",
               "format": "date",
@@ -6697,16 +6362,19 @@ final dynamic sampleSMCFlows = {
                 {
                   "type": "required",
                   "value": true,
-                  "message": "APPONE_REGISTRATION_HOUSEHOLDDETAILS_label_dateOfRegistration_mandatory_message"
+                  "message":
+                      "APPONE_REGISTRATION_HOUSEHOLDDETAILS_label_dateOfRegistration_mandatory_message"
                 }
               ],
               "errorMessage": "REGISTRATION_HOUSEHOLD_dateOfRegistration_ERROR",
               "isMultiSelect": false,
-              "required.message": "APPONE_REGISTRATION_HOUSEHOLDDETAILS_label_dateOfRegistration_mandatory_message"
+              "required.message":
+                  "APPONE_REGISTRATION_HOUSEHOLDDETAILS_label_dateOfRegistration_mandatory_message"
             },
             {
               "type": "integer",
-              "label": "APPONE_REGISTRATION_HOUSEHOLDDETAILS_label_childrenCount",
+              "label":
+                  "APPONE_REGISTRATION_HOUSEHOLDDETAILS_label_childrenCount",
               "order": 2,
               "value": "0",
               "format": "numeric",
@@ -6728,7 +6396,8 @@ final dynamic sampleSMCFlows = {
             },
             {
               "type": "integer",
-              "label": "APPONE_REGISTRATION_HOUSEHOLDDETAILS_label_pregnantWomenCount",
+              "label":
+                  "APPONE_REGISTRATION_HOUSEHOLDDETAILS_label_pregnantWomenCount",
               "order": 3,
               "value": "0",
               "format": "numeric",
@@ -6755,7 +6424,8 @@ final dynamic sampleSMCFlows = {
               "range": {
                 "max": "10",
                 "min": "1",
-                "errorMessage": "APPONE_REGISTRATION_HOUSEHOLDDETAILS_label_memberCount_max_message"
+                "errorMessage":
+                    "APPONE_REGISTRATION_HOUSEHOLDDETAILS_label_memberCount_max_message"
               },
               "value": "1",
               "format": "numeric",
@@ -6776,32 +6446,36 @@ final dynamic sampleSMCFlows = {
                 {
                   "type": "required",
                   "value": true,
-                  "message": "APPONE_REGISTRATION_HOUSEHOLDDETAILS_label_memberCount_mandatory_message"
+                  "message":
+                      "APPONE_REGISTRATION_HOUSEHOLDDETAILS_label_memberCount_mandatory_message"
                 },
                 {
                   "type": "min",
                   "value": "1",
-                  "message": "APPONE_REGISTRATION_HOUSEHOLDDETAILS_label_memberCount_max_message"
+                  "message":
+                      "APPONE_REGISTRATION_HOUSEHOLDDETAILS_label_memberCount_max_message"
                 },
                 {
                   "type": "max",
                   "value": "10",
-                  "message": "APPONE_REGISTRATION_HOUSEHOLDDETAILS_label_memberCount_max_message"
+                  "message":
+                      "APPONE_REGISTRATION_HOUSEHOLDDETAILS_label_memberCount_max_message"
                 }
               ],
               "errorMessage": "REGISTRATION_HOUSEHOLD_memberCount_ERROR",
               "isMultiSelect": false,
-              "required.message": "APPONE_REGISTRATION_HOUSEHOLDDETAILS_label_memberCount_mandatory_message"
+              "required.message":
+                  "APPONE_REGISTRATION_HOUSEHOLDDETAILS_label_memberCount_mandatory_message"
             }
           ],
-          "actionLabel": "APPONE_REGISTRATION_HOUSEHOLDDETAILS_ACTION_BUTTON_LABEL_1",
-          "description": "APPONE_REGISTRATION_HOUSEHOLDDETAILS_SCREEN_DESCRIPTION",
+          "actionLabel":
+              "APPONE_REGISTRATION_HOUSEHOLDDETAILS_ACTION_BUTTON_LABEL_1",
+          "description":
+              "APPONE_REGISTRATION_HOUSEHOLDDETAILS_SCREEN_DESCRIPTION",
           "showTabView": false,
           "submitCondition": {
             "expression": [
-              {
-                "condition": "isEdit == true"
-              }
+              {"condition": "isEdit == true"}
             ]
           },
           "preventScreenCapture": false
@@ -6815,15 +6489,13 @@ final dynamic sampleSMCFlows = {
           "order": 1,
           "footer": [
             {
-              "label": "APPONE_REGISTRATION_BENEFICIARY_LOCATION_ACTION_BUTTON_LABEL_1",
+              "label":
+                  "APPONE_REGISTRATION_BENEFICIARY_LOCATION_ACTION_BUTTON_LABEL_1",
               "format": "button",
               "onAction": [
                 {
                   "actionType": "NAVIGATION",
-                  "properties": {
-                    "name": "householdDetails",
-                    "type": "form"
-                  }
+                  "properties": {"name": "householdDetails", "type": "form"}
                 }
               ],
               "properties": {
@@ -6860,10 +6532,7 @@ final dynamic sampleSMCFlows = {
                   "properties": {
                     "entity": "HouseholdModel, TaskModel",
                     "modify": [
-                      {
-                        "key": "TaskModel.status",
-                        "value": "NOT_ADMINISTERED"
-                      }
+                      {"key": "TaskModel.status", "value": "NOT_ADMINISTERED"}
                     ],
                     "onError": [
                       {
@@ -6881,7 +6550,8 @@ final dynamic sampleSMCFlows = {
                     "data": [
                       {
                         "key": "HouseholdClientReferenceId",
-                        "value": "{{contextData.entities.HouseholdModel.clientReferenceId}}"
+                        "value":
+                            "{{contextData.entities.HouseholdModel.clientReferenceId}}"
                       }
                     ],
                     "name": "householdOverview",
@@ -6889,9 +6559,7 @@ final dynamic sampleSMCFlows = {
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {
-                          "message": "Navigation failed."
-                        }
+                        "properties": {"message": "Navigation failed."}
                       }
                     ],
                     "navigationMode": "popUntilAndPush",
@@ -6912,9 +6580,7 @@ final dynamic sampleSMCFlows = {
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {
-                          "message": "Failed to fetch config."
-                        }
+                        "properties": {"message": "Failed to fetch config."}
                       }
                     ],
                     "configName": "beneficiaryRegistration"
@@ -6927,9 +6593,7 @@ final dynamic sampleSMCFlows = {
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {
-                          "message": "Failed to update household."
-                        }
+                        "properties": {"message": "Failed to update household."}
                       }
                     ]
                   }
@@ -6940,7 +6604,8 @@ final dynamic sampleSMCFlows = {
                     "data": [
                       {
                         "key": "HouseholdClientReferenceId",
-                        "value": "{{contextData.entities.HouseholdModel.clientReferenceId}}"
+                        "value":
+                            "{{contextData.entities.HouseholdModel.clientReferenceId}}"
                       }
                     ],
                     "name": "householdOverview",
@@ -6948,9 +6613,7 @@ final dynamic sampleSMCFlows = {
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {
-                          "message": "Navigation failed."
-                        }
+                        "properties": {"message": "Navigation failed."}
                       }
                     ],
                     "navigationMode": "popUntilAndPush",
@@ -6958,10 +6621,7 @@ final dynamic sampleSMCFlows = {
                   }
                 }
               ],
-              "condition": {
-                "type": "custom",
-                "expression": "isEdit==true"
-              }
+              "condition": {"type": "custom", "expression": "isEdit==true"}
             },
             {
               "actions": [
@@ -6971,9 +6631,7 @@ final dynamic sampleSMCFlows = {
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {
-                          "message": "Failed to fetch config."
-                        }
+                        "properties": {"message": "Failed to fetch config."}
                       }
                     ],
                     "configName": "beneficiaryRegistration"
@@ -6982,13 +6640,12 @@ final dynamic sampleSMCFlows = {
                 {
                   "actionType": "CREATE_EVENT",
                   "properties": {
-                    "entity": "HOUSEHOLD, INDIVIDUAL, PROJECTBENEFICIARY, MEMBER",
+                    "entity":
+                        "HOUSEHOLD, INDIVIDUAL, PROJECTBENEFICIARY, MEMBER",
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {
-                          "message": "Failed to create household."
-                        }
+                        "properties": {"message": "Failed to create household."}
                       }
                     ]
                   }
@@ -6999,7 +6656,8 @@ final dynamic sampleSMCFlows = {
                     "data": [
                       {
                         "key": "HouseholdClientReferenceId",
-                        "value": "{{contextData.entities.HouseholdModel.clientReferenceId}}"
+                        "value":
+                            "{{contextData.entities.HouseholdModel.clientReferenceId}}"
                       }
                     ],
                     "name": "householdOverview",
@@ -7007,9 +6665,7 @@ final dynamic sampleSMCFlows = {
                     "onError": [
                       {
                         "actionType": "SHOW_TOAST",
-                        "properties": {
-                          "message": "Navigation failed."
-                        }
+                        "properties": {"message": "Navigation failed."}
                       }
                     ],
                     "navigationMode": "popUntilAndPush",
@@ -7017,26 +6673,23 @@ final dynamic sampleSMCFlows = {
                   }
                 }
               ],
-              "condition": {
-                "expression": "DEFAULT"
-              }
+              "condition": {"expression": "DEFAULT"}
             }
           ],
-          "navigateTo": {
-            "name": "householdDetails",
-            "type": "form"
-          },
+          "navigateTo": {"name": "householdDetails", "type": "form"},
           "properties": [
             {
               "type": "string",
-              "label": "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_administrativeArea",
+              "label":
+                  "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_administrativeArea",
               "order": 1,
               "value": "",
               "format": "locality",
               "hidden": false,
               "isMdms": false,
               "tooltip": "",
-              "helpText": "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_administrativeArea_helpText",
+              "helpText":
+                  "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_administrativeArea_helpText",
               "infoText": "",
               "readOnly": false,
               "required": true,
@@ -7050,12 +6703,14 @@ final dynamic sampleSMCFlows = {
                 {
                   "type": "required",
                   "value": true,
-                  "message": "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_administrativeArea_mandatory_message"
+                  "message":
+                      "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_administrativeArea_mandatory_message"
                 }
               ],
               "errorMessage": "REGISTRATION_HOUSEHOLD_administrativeArea_ERROR",
               "isMultiSelect": false,
-              "required.message": "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_administrativeArea_mandatory_message"
+              "required.message":
+                  "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_administrativeArea_mandatory_message"
             },
             {
               "type": "string",
@@ -7066,7 +6721,8 @@ final dynamic sampleSMCFlows = {
               "hidden": false,
               "isMdms": false,
               "tooltip": "",
-              "helpText": "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_latlong_helpText",
+              "helpText":
+                  "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_latlong_helpText",
               "infoText": "",
               "readOnly": false,
               "required": true,
@@ -7080,23 +6736,27 @@ final dynamic sampleSMCFlows = {
                 {
                   "type": "required",
                   "value": true,
-                  "message": "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_latlong_mandatory_message"
+                  "message":
+                      "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_latlong_mandatory_message"
                 }
               ],
               "errorMessage": "REGISTRATION_HOUSEHOLD_latLng_ERROR",
               "isMultiSelect": false,
-              "required.message": "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_latlong_mandatory_message"
+              "required.message":
+                  "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_latlong_mandatory_message"
             },
             {
               "type": "string",
-              "label": "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_addressLine1",
+              "label":
+                  "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_addressLine1",
               "order": 3,
               "value": "",
               "format": "text",
               "hidden": true,
               "isMdms": false,
               "tooltip": "",
-              "helpText": "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_addressLine1_helpText",
+              "helpText":
+                  "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_addressLine1_helpText",
               "infoText": "",
               "readOnly": false,
               "fieldName": "addressLine1",
@@ -7107,13 +6767,15 @@ final dynamic sampleSMCFlows = {
               "systemDate": false,
               "lengthRange": {
                 "minLength": "2",
-                "errorMessage": "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_addressLine1_min_message"
+                "errorMessage":
+                    "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_addressLine1_min_message"
               },
               "validations": [
                 {
                   "type": "minLength",
                   "value": "2",
-                  "message": "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_addressLine1_min_message"
+                  "message":
+                      "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_addressLine1_min_message"
                 }
               ],
               "errorMessage": "REGISTRATION_HOUSEHOLD_addressLine1_ERROR",
@@ -7121,14 +6783,16 @@ final dynamic sampleSMCFlows = {
             },
             {
               "type": "string",
-              "label": "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_addressLine2",
+              "label":
+                  "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_addressLine2",
               "order": 4,
               "value": "",
               "format": "text",
               "hidden": true,
               "isMdms": false,
               "tooltip": "",
-              "helpText": "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_addressLine2_helpText",
+              "helpText":
+                  "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_addressLine2_helpText",
               "infoText": "",
               "readOnly": false,
               "fieldName": "addressLine2",
@@ -7139,13 +6803,15 @@ final dynamic sampleSMCFlows = {
               "systemDate": false,
               "lengthRange": {
                 "minLength": "2",
-                "errorMessage": "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_addressLine2_min_message"
+                "errorMessage":
+                    "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_addressLine2_min_message"
               },
               "validations": [
                 {
                   "type": "minLength",
                   "value": "2",
-                  "message": "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_addressLine2_min_message"
+                  "message":
+                      "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_addressLine2_min_message"
                 }
               ],
               "errorMessage": "REGISTRATION_HOUSEHOLD_addressLine2_ERROR",
@@ -7160,7 +6826,8 @@ final dynamic sampleSMCFlows = {
               "hidden": true,
               "isMdms": false,
               "tooltip": "",
-              "helpText": "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_landmark_helpText",
+              "helpText":
+                  "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_landmark_helpText",
               "infoText": "",
               "readOnly": false,
               "fieldName": "landmark",
@@ -7171,13 +6838,15 @@ final dynamic sampleSMCFlows = {
               "systemDate": false,
               "lengthRange": {
                 "minLength": "2",
-                "errorMessage": "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_landmark_min_message"
+                "errorMessage":
+                    "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_landmark_min_message"
               },
               "validations": [
                 {
                   "type": "minLength",
                   "value": "2",
-                  "message": "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_landmark_min_message"
+                  "message":
+                      "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_landmark_min_message"
                 }
               ],
               "errorMessage": "REGISTRATION_HOUSEHOLD_landmark_ERROR",
@@ -7193,7 +6862,8 @@ final dynamic sampleSMCFlows = {
               "isMdms": false,
               "pattern": "^\\d+",
               "tooltip": "",
-              "helpText": "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_pincode_helpText",
+              "helpText":
+                  "APPONE_REGISTRATION_BENEFICIARYLOCATION_label_pincode_helpText",
               "infoText": "",
               "readOnly": false,
               "fieldName": "pincode",
@@ -7215,20 +6885,15 @@ final dynamic sampleSMCFlows = {
             {
               "type": "string",
               "enums": [
-                {
-                  "code": "PERMANENT",
-                  "name": "BENEFICIARYLOCATION_PERMANENT"
-                },
+                {"code": "PERMANENT", "name": "BENEFICIARYLOCATION_PERMANENT"},
                 {
                   "code": "CORRESPONDENCE",
                   "name": "BENEFICIARYLOCATION_CORRESPONDENCE"
                 },
-                {
-                  "code": "OTHER",
-                  "name": "BENEFICIARYLOCATION_OTHER"
-                }
+                {"code": "OTHER", "name": "BENEFICIARYLOCATION_OTHER"}
               ],
-              "label": "APPONE_REGISTRATION_BENEFICIARY_LOCATION_label_typeOfAddress",
+              "label":
+                  "APPONE_REGISTRATION_BENEFICIARY_LOCATION_label_typeOfAddress",
               "order": 7,
               "value": "PERMANENT",
               "format": "dropdown",
@@ -7249,24 +6914,20 @@ final dynamic sampleSMCFlows = {
               "includeInForm": true,
               "isMultiSelect": false,
               "dropDownOptions": [
-                {
-                  "code": "PERMANENT",
-                  "name": "BENEFICIARYLOCATION_PERMANENT"
-                },
+                {"code": "PERMANENT", "name": "BENEFICIARYLOCATION_PERMANENT"},
                 {
                   "code": "CORRESPONDENCE",
                   "name": "BENEFICIARYLOCATION_CORRESPONDENCE"
                 },
-                {
-                  "code": "OTHER",
-                  "name": "BENEFICIARYLOCATION_OTHER"
-                }
+                {"code": "OTHER", "name": "BENEFICIARYLOCATION_OTHER"}
               ],
               "includeInSummary": false
             }
           ],
-          "actionLabel": "APPONE_REGISTRATION_BENEFICIARY_LOCATION_ACTION_BUTTON_LABEL_1",
-          "description": "APPONE_REGISTRATION_BENEFICIARY_LOCATION_SCREEN_DESCRIPTION",
+          "actionLabel":
+              "APPONE_REGISTRATION_BENEFICIARY_LOCATION_ACTION_BUTTON_LABEL_1",
+          "description":
+              "APPONE_REGISTRATION_BENEFICIARY_LOCATION_SCREEN_DESCRIPTION",
           "showTabView": false,
           "submitCondition": null,
           "preventScreenCapture": false
@@ -7285,9 +6946,7 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {
-                      "message": "REGISTRATION_HOUSEHOLD_MESSAGE"
-                    }
+                    "properties": {"message": "REGISTRATION_HOUSEHOLD_MESSAGE"}
                   }
                 ],
                 "configName": "beneficiaryRegistration"
@@ -7298,10 +6957,7 @@ final dynamic sampleSMCFlows = {
               "properties": {
                 "entity": "HouseholdModel, TaskModel",
                 "modify": [
-                  {
-                    "key": "TaskModel.status",
-                    "value": "NOT_ADMINISTERED"
-                  }
+                  {"key": "TaskModel.status", "value": "NOT_ADMINISTERED"}
                 ],
                 "onError": [
                   {
@@ -7319,7 +6975,8 @@ final dynamic sampleSMCFlows = {
                 "data": [
                   {
                     "key": "HouseholdClientReferenceId",
-                    "value": "{{contextData.entities.HouseholdModel.clientReferenceId}}"
+                    "value":
+                        "{{contextData.entities.HouseholdModel.clientReferenceId}}"
                   }
                 ],
                 "name": "householdOverview",
@@ -7327,9 +6984,7 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {
-                      "message": "Navigation failed."
-                    }
+                    "properties": {"message": "Navigation failed."}
                   }
                 ],
                 "navigationMode": "popUntilAndPush",
@@ -7349,9 +7004,7 @@ final dynamic sampleSMCFlows = {
             "onError": [
               {
                 "actionType": "SHOW_TOAST",
-                "properties": {
-                  "message": "Failed to update stock balance."
-                }
+                "properties": {"message": "Failed to update stock balance."}
               }
             ]
           }
@@ -7364,9 +7017,7 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {
-                      "message": "Failed to fetch config."
-                    }
+                    "properties": {"message": "Failed to fetch config."}
                   }
                 ],
                 "configName": "beneficiaryRegistration"
@@ -7379,9 +7030,7 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {
-                      "message": "Failed to update household."
-                    }
+                    "properties": {"message": "Failed to update household."}
                   }
                 ]
               }
@@ -7392,7 +7041,8 @@ final dynamic sampleSMCFlows = {
                 "data": [
                   {
                     "key": "HouseholdClientReferenceId",
-                    "value": "{{contextData.entities.HouseholdModel.clientReferenceId}}"
+                    "value":
+                        "{{contextData.entities.HouseholdModel.clientReferenceId}}"
                   }
                 ],
                 "name": "householdOverview",
@@ -7400,9 +7050,7 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {
-                      "message": "Navigation failed."
-                    }
+                    "properties": {"message": "Navigation failed."}
                   }
                 ],
                 "navigationMode": "popUntilAndPush",
@@ -7410,10 +7058,7 @@ final dynamic sampleSMCFlows = {
               }
             }
           ],
-          "condition": {
-            "type": "custom",
-            "expression": "isEdit==true"
-          }
+          "condition": {"type": "custom", "expression": "isEdit==true"}
         },
         {
           "actions": [
@@ -7423,9 +7068,7 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {
-                      "message": "Failed to fetch config."
-                    }
+                    "properties": {"message": "Failed to fetch config."}
                   }
                 ],
                 "configName": "beneficiaryRegistration"
@@ -7452,9 +7095,7 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {
-                      "message": "Failed to create household."
-                    }
+                    "properties": {"message": "Failed to create household."}
                   }
                 ]
               }
@@ -7465,7 +7106,8 @@ final dynamic sampleSMCFlows = {
                 "data": [
                   {
                     "key": "HouseholdClientReferenceId",
-                    "value": "{{contextData.entities.HouseholdModel.clientReferenceId}}"
+                    "value":
+                        "{{contextData.entities.HouseholdModel.clientReferenceId}}"
                   }
                 ],
                 "name": "householdOverview",
@@ -7473,9 +7115,7 @@ final dynamic sampleSMCFlows = {
                 "onError": [
                   {
                     "actionType": "SHOW_TOAST",
-                    "properties": {
-                      "message": "Navigation failed."
-                    }
+                    "properties": {"message": "Navigation failed."}
                   }
                 ],
                 "navigationMode": "popUntilAndPush",
@@ -7483,9 +7123,7 @@ final dynamic sampleSMCFlows = {
               }
             }
           ],
-          "condition": {
-            "expression": "DEFAULT"
-          }
+          "condition": {"expression": "DEFAULT"}
         }
       ],
       "isSelected": true,
@@ -7493,10 +7131,7 @@ final dynamic sampleSMCFlows = {
       "initActions": [],
       "wrapperConfig": {
         "filters": [
-          {
-            "field": "isHeadOfHousehold",
-            "equals": true
-          }
+          {"field": "isHeadOfHousehold", "equals": true}
         ],
         "relations": [
           {

--- a/apps/health_campaign_field_worker_app/lib/utils/utils.dart
+++ b/apps/health_campaign_field_worker_app/lib/utils/utils.dart
@@ -43,7 +43,6 @@ import '../data/local_store/app_shared_preferences.dart';
 import '../data/local_store/no_sql/schema/app_configuration.dart';
 import '../data/local_store/no_sql/schema/localization.dart';
 import '../data/local_store/secure_store/secure_store.dart';
-import '../models/app_config/app_config_model.dart';
 import '../router/app_router.dart';
 import '../widgets/progress_indicator/progress_indicator.dart';
 import 'constants.dart';
@@ -148,10 +147,6 @@ String maskString(String input) {
       List<String>.generate(input.length, (index) => maskingChar).join();
 
   return maskedString;
-}
-
-List<MdmsMasterDetailModel> getMasterDetailsModel(List<String> masterNames) {
-  return masterNames.map((e) => MdmsMasterDetailModel(e)).toList();
 }
 
 Timer makePeriodicTimer(

--- a/apps/health_campaign_field_worker_app/test/mdms_v2_repository_test.dart
+++ b/apps/health_campaign_field_worker_app/test/mdms_v2_repository_test.dart
@@ -40,8 +40,7 @@ class _FakeMdmsV2Adapter implements HttpClientAdapter {
   void close({bool force = false}) {}
 }
 
-// Sample records in the real v2 response shape shared from
-// unified-dev (HCM-ADMIN-CONSOLE.targetConfigs).
+// Sample records in the real v2 response shape.
 Map<String, dynamic> _v2Record({
   required String schemaCode,
   required Map<String, dynamic> data,
@@ -58,8 +57,8 @@ Map<String, dynamic> _v2Record({
     };
 
 void main() {
-  group('MdmsRepository v2 adapter', () {
-    test('reassembles flat v2 mdms list into v1 MdmsRes nesting', () async {
+  group('MdmsRepository v2 native', () {
+    test('searchMDMS returns flat data list from v2 response', () async {
       final adapter = _FakeMdmsV2Adapter({
         'HCM-ADMIN-CONSOLE.targetConfigs': [
           _v2Record(
@@ -72,75 +71,35 @@ void main() {
             isActive: false,
           ),
         ],
-        'common-masters.GenderType': [
-          _v2Record(
-            schemaCode: 'common-masters.GenderType',
-            data: {'code': 'MALE', 'name': 'Male'},
-          ),
-        ],
       });
       final dio = Dio()..httpClientAdapter = adapter;
       final repository = MdmsRepository(dio);
 
       final result = await repository.searchMDMS(
         'egov-mdms-service/v2/_search',
-        {
-          'MdmsCriteria': {
-            'tenantId': 'mz',
-            'moduleDetails': [
-              {
-                'moduleName': 'HCM-ADMIN-CONSOLE',
-                'masterDetails': [
-                  {'name': 'targetConfigs'},
-                ],
-              },
-              {
-                'moduleName': 'common-masters',
-                'masterDetails': [
-                  {'name': 'GenderType'},
-                ],
-              },
-            ],
-          },
-        },
+        tenantId: 'mz',
+        schemaCode: 'HCM-ADMIN-CONSOLE.targetConfigs',
       );
 
-      // One v2 call per module.master schemaCode.
-      expect(adapter.capturedRequests, hasLength(2));
+      // One v2 call made.
+      expect(adapter.capturedRequests, hasLength(1));
       expect(
-        adapter.capturedRequests.first['MdmsCriteria'],
-        equals({
-          'tenantId': 'mz',
-          'schemaCode': 'HCM-ADMIN-CONSOLE.targetConfigs',
-          'limit': 2000,
-        }),
+        adapter.capturedRequests.first['MdmsCriteria']['schemaCode'],
+        equals('HCM-ADMIN-CONSOLE.targetConfigs'),
       );
 
-      // v1-shaped nesting, inactive records dropped.
-      final targetConfigs = result['HCM-ADMIN-CONSOLE']['targetConfigs'];
-      expect(targetConfigs, hasLength(1));
-      expect(targetConfigs.first['campaignType'], 'Co-delivery');
-      expect(
-        result['common-masters']['GenderType'].first['code'],
-        'MALE',
-      );
+      // Returns flat list of data objects, inactive records dropped.
+      expect(result, hasLength(1));
+      expect(result.first['campaignType'], 'Co-delivery');
     });
 
-    test('applies v1 JSONPath filter client-side', () async {
+    test('searchMDMS passes filters to v2 request', () async {
       final adapter = _FakeMdmsV2Adapter({
         'HCM-ADMIN-CONSOLE.FormConfig': [
           _v2Record(
             schemaCode: 'HCM-ADMIN-CONSOLE.FormConfig',
             data: {'project': 'P-1', 'isSelected': true, 'name': 'match'},
           ),
-          _v2Record(
-            schemaCode: 'HCM-ADMIN-CONSOLE.FormConfig',
-            data: {'project': 'P-1', 'isSelected': false, 'name': 'no-1'},
-          ),
-          _v2Record(
-            schemaCode: 'HCM-ADMIN-CONSOLE.FormConfig',
-            data: {'project': 'P-2', 'isSelected': true, 'name': 'no-2'},
-          ),
         ],
       });
       final dio = Dio()..httpClientAdapter = adapter;
@@ -148,31 +107,22 @@ void main() {
 
       final result = await repository.searchMDMS(
         'egov-mdms-service/v2/_search',
-        {
-          'MdmsCriteria': {
-            'tenantId': 'mz',
-            'moduleDetails': [
-              {
-                'moduleName': 'HCM-ADMIN-CONSOLE',
-                'masterDetails': [
-                  {
-                    'name': 'FormConfig',
-                    'filter': "[?(@.project=='P-1' && @.isSelected==true)]",
-                  },
-                ],
-              },
-            ],
-          },
-        },
+        tenantId: 'mz',
+        schemaCode: 'HCM-ADMIN-CONSOLE.FormConfig',
+        filters: {'project': 'P-1'},
       );
 
-      final formConfigs = result['HCM-ADMIN-CONSOLE']['FormConfig'];
-      expect(formConfigs, hasLength(1));
-      expect(formConfigs.first['name'], 'match');
+      // Verify filters were sent in the request.
+      expect(
+        adapter.capturedRequests.first['MdmsCriteria']['filters'],
+        equals({'project': 'P-1'}),
+      );
+
+      expect(result, hasLength(1));
+      expect(result.first['name'], 'match');
     });
 
-    test('parses service registry wrapper from reassembled response',
-        () async {
+    test('parses service registry wrapper from v2 response', () async {
       final adapter = _FakeMdmsV2Adapter({
         'HCM-SERVICE-REGISTRY.serviceRegistry': [
           _v2Record(
@@ -195,25 +145,41 @@ void main() {
 
       final result = await repository.searchServiceRegistry(
         'egov-mdms-service/v2/_search',
-        {
-          'MdmsCriteria': {
-            'tenantId': 'mz',
-            'moduleDetails': [
-              {
-                'moduleName': 'HCM-SERVICE-REGISTRY',
-                'masterDetails': [
-                  {'name': 'serviceRegistry'},
-                ],
-              },
-            ],
-          },
-        },
+        'mz',
       );
 
       final registry = result.serviceRegistry?.serviceRegistryList;
       expect(registry, hasLength(1));
       expect(registry!.first.service, 'Project');
       expect(registry.first.actions.first.path, '/project/v1/_search');
+    });
+
+    test('searchProjectType parses v2 response', () async {
+      final adapter = _FakeMdmsV2Adapter({
+        'HCM-PROJECT-TYPES.projectTypes': [
+          _v2Record(
+            schemaCode: 'HCM-PROJECT-TYPES.projectTypes',
+            data: {
+              'id': 'pt-1',
+              'code': 'LLIN',
+              'name': 'LLIN Distribution',
+              'group': 'MALARIA',
+              'beneficiaryType': 'HOUSEHOLD',
+            },
+          ),
+        ],
+      });
+      final dio = Dio()..httpClientAdapter = adapter;
+      final repository = MdmsRepository(dio);
+
+      final result = await repository.searchProjectType(
+        'egov-mdms-service/v2/_search',
+        'mz',
+      );
+
+      final types = result.projectTypeWrapper?.projectTypes;
+      expect(types, hasLength(1));
+      expect(types!.first.code, 'LLIN');
     });
   });
 }

--- a/packages/digit_flow_builder/lib/blocs/wrapper/computed_field_processor.dart
+++ b/packages/digit_flow_builder/lib/blocs/wrapper/computed_field_processor.dart
@@ -1,7 +1,9 @@
 import 'package:digit_formula_parser/digit_formula_parser.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/cupertino.dart';
 
 import '../../utils/utils.dart';
+import 'computed_list_evaluator.dart';
 import 'condition_evaluator.dart';
 import 'computed_evaluator.dart';
 import 'field_evaluator.dart';
@@ -70,6 +72,8 @@ class ComputedFieldProcessor {
         results[key] = conf['fallback'];
       }
 
+      debugPrint('[ComputedField] $key => ${results[key]}');
+
       // Add to context for subsequent computed fields to reference
       context[key] = results[key];
     }
@@ -120,9 +124,8 @@ class ComputedFieldProcessor {
       );
 
       try {
-        // TODO: Fix condition format in configuration files - replace 'and' with '&&' for proper formula parser syntax
         final sanitizedCondition =
-            condition.replaceAll(' and ', ' && ').replaceAll('and', '&&');
+            ComputedListEvaluator.sanitizeCondition(condition);
         final parser = FormulaParser(sanitizedCondition, flatContext);
         final result = parser.parse;
 

--- a/packages/digit_flow_builder/lib/blocs/wrapper/computed_field_processor.dart
+++ b/packages/digit_flow_builder/lib/blocs/wrapper/computed_field_processor.dart
@@ -72,8 +72,6 @@ class ComputedFieldProcessor {
         results[key] = conf['fallback'];
       }
 
-      debugPrint('[ComputedField] $key => ${results[key]}');
-
       // Add to context for subsequent computed fields to reference
       context[key] = results[key];
     }

--- a/packages/digit_flow_builder/lib/blocs/wrapper/computed_list_evaluator.dart
+++ b/packages/digit_flow_builder/lib/blocs/wrapper/computed_list_evaluator.dart
@@ -12,10 +12,6 @@ class ComputedListEvaluator {
   static List<dynamic> evaluate(
       Map<String, dynamic> ctx, Map<String, dynamic> conf) {
     var list = resolveValueRaw(conf['from'], ctx);
-    debugPrint('[ComputedListEval] from="${conf['from']}" => '
-        'resolved type=${list?.runtimeType}, '
-        'isIterable=${list is Iterable}, '
-        'hasEvalCondition=${conf.containsKey('evaluateCondition')}');
     if (list is! Iterable) return [];
 
     // Handle evaluateCondition for formula-based filtering
@@ -261,8 +257,6 @@ class ComputedListEvaluator {
         final defaultValue =
             _getDefaultValueForMissingKey(key, resolvedCondition);
         contextMap[key] = defaultValue;
-        debugPrint(
-            'Missing key "$key" in context, using default: $defaultValue');
       }
     }
 
@@ -298,9 +292,6 @@ class ComputedListEvaluator {
         final sanitizedCondition = sanitizeCondition(resolvedCondition);
         final parser = FormulaParser(sanitizedCondition, flatContext);
         final result = parser.parse;
-        debugPrint('[ComputedListEval] condition="$sanitizedCondition" '
-            'context=${flatContext.entries.where((e) => e.key == 'age' || e.key == 'gender').map((e) => '${e.key}=${e.value}').join(', ')} '
-            '=> isSuccess=${result['isSuccess']}, value=${result['value']}');
 
         if (result['isSuccess'] && result['value'] == true) {
           results.add(item);

--- a/packages/digit_flow_builder/lib/blocs/wrapper/computed_list_evaluator.dart
+++ b/packages/digit_flow_builder/lib/blocs/wrapper/computed_list_evaluator.dart
@@ -12,6 +12,10 @@ class ComputedListEvaluator {
   static List<dynamic> evaluate(
       Map<String, dynamic> ctx, Map<String, dynamic> conf) {
     var list = resolveValueRaw(conf['from'], ctx);
+    debugPrint('[ComputedListEval] from="${conf['from']}" => '
+        'resolved type=${list?.runtimeType}, '
+        'isIterable=${list is Iterable}, '
+        'hasEvalCondition=${conf.containsKey('evaluateCondition')}');
     if (list is! Iterable) return [];
 
     // Handle evaluateCondition for formula-based filtering
@@ -291,12 +295,12 @@ class ComputedListEvaluator {
       if (resolvedCondition == null || resolvedCondition.isEmpty) continue;
 
       try {
-        // TODO: Fix condition format in configuration files - replace 'and' with '&&' for proper formula parser syntax
-        final sanitizedCondition = resolvedCondition
-            .replaceAll(' and ', ' && ')
-            .replaceAll('and', '&&');
+        final sanitizedCondition = sanitizeCondition(resolvedCondition);
         final parser = FormulaParser(sanitizedCondition, flatContext);
         final result = parser.parse;
+        debugPrint('[ComputedListEval] condition="$sanitizedCondition" '
+            'context=${flatContext.entries.where((e) => e.key == 'age' || e.key == 'gender').map((e) => '${e.key}=${e.value}').join(', ')} '
+            '=> isSuccess=${result['isSuccess']}, value=${result['value']}');
 
         if (result['isSuccess'] && result['value'] == true) {
           results.add(item);
@@ -320,6 +324,28 @@ class ComputedListEvaluator {
     }
 
     return results;
+  }
+
+  /// Sanitizes a condition string for FormulaParser:
+  /// 1. Replaces `and` with `&&`
+  /// 2. Expands chained comparisons like `60<=age<=180` into
+  ///    `60<=age&&age<=180` since FormulaParser does not support
+  ///    Python-style chained comparisons.
+  static String sanitizeCondition(String condition) {
+    var sanitized = condition
+        .replaceAll(' and ', ' && ')
+        .replaceAll('and', '&&');
+
+    // Expand chained comparisons: "60<=age<=180" → "60<=age&&age<=180"
+    // Pattern: number op variable op number
+    final chainedPattern = RegExp(
+      r'(\d+(?:\.\d+)?)\s*(<=|>=|<|>)\s*([a-zA-Z_]\w*)\s*(<=|>=|<|>)\s*(\d+(?:\.\d+)?)',
+    );
+    sanitized = sanitized.replaceAllMapped(chainedPattern, (m) {
+      return '${m[1]}${m[2]}${m[3]}&&${m[3]}${m[4]}${m[5]}';
+    });
+
+    return sanitized;
   }
 
   static Iterable<T> _takeWhile<T>(

--- a/packages/digit_flow_builder/lib/utils/function_registry.dart
+++ b/packages/digit_flow_builder/lib/utils/function_registry.dart
@@ -435,7 +435,6 @@ void initializeFunctionRegistry() {
     bool? ageEligibleByCondition;
     if (minAge == null || maxAge == null) {
       ageEligibleByCondition = false;
-      debugPrint('[EligibilityCheck] No validMinAge/validMaxAge, falling back to doseCriteria. age=$totalAgeMonths months');
       for (final cycle in projectType.cycles ?? []) {
         if ((cycle.startDate ?? 0) < DateTime.now().millisecondsSinceEpoch &&
             (cycle.endDate ?? 0) > DateTime.now().millisecondsSinceEpoch) {
@@ -459,22 +458,19 @@ void initializeFunctionRegistry() {
                 if (ageParts.isEmpty) {
                   // No age constraint in condition — treat as age-eligible
                   ageEligibleByCondition = true;
-                  debugPrint('[EligibilityCheck] condition="$condition" has no age constraint, treating as eligible');
                   break;
                 }
                 final ageOnlyCondition = ageParts.join('&&');
-                debugPrint('[EligibilityCheck] condition="$condition" -> ageOnly="$ageOnlyCondition" age=$totalAgeMonths');
                 final parser = FormulaParser(
                     ageOnlyCondition, {'age': totalAgeMonths});
                 final result = parser.parse;
-                debugPrint('[EligibilityCheck] result: isSuccess=${result['isSuccess']}, value=${result['value']}');
                 if (result['isSuccess'] == true &&
                     result['value'] == true) {
                   ageEligibleByCondition = true;
                   break;
                 }
               } catch (e) {
-                debugPrint('[EligibilityCheck] Age condition evaluation error: $e');
+                debugPrint('Age condition evaluation error: $e');
               }
             }
             if (ageEligibleByCondition == true) break;
@@ -482,7 +478,6 @@ void initializeFunctionRegistry() {
           break;
         }
       }
-      debugPrint('[EligibilityCheck] ageEligibleByCondition=$ageEligibleByCondition');
     }
 
 // --- Tasks & SideEffects come from stateData ---

--- a/packages/digit_flow_builder/lib/utils/function_registry.dart
+++ b/packages/digit_flow_builder/lib/utils/function_registry.dart
@@ -10,6 +10,7 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
 import '../blocs/app_localization.dart';
+import '../blocs/wrapper/computed_list_evaluator.dart';
 import 'interpolation.dart';
 
 /// English month abbreviations indexed by [DateTime.month] (1-based).
@@ -434,6 +435,7 @@ void initializeFunctionRegistry() {
     bool? ageEligibleByCondition;
     if (minAge == null || maxAge == null) {
       ageEligibleByCondition = false;
+      debugPrint('[EligibilityCheck] No validMinAge/validMaxAge, falling back to doseCriteria. age=$totalAgeMonths months');
       for (final cycle in projectType.cycles ?? []) {
         if ((cycle.startDate ?? 0) < DateTime.now().millisecondsSinceEpoch &&
             (cycle.endDate ?? 0) > DateTime.now().millisecondsSinceEpoch) {
@@ -445,19 +447,34 @@ void initializeFunctionRegistry() {
                 break;
               }
               try {
-                final sanitizedCondition = condition
-                    .replaceAll(' and ', ' && ')
-                    .replaceAll('and', '&&');
+                // Sanitize: expand chained comparisons and replace 'and' with '&&'
+                final sanitizedCondition =
+                    ComputedListEvaluator.sanitizeCondition(condition);
+                // Extract only age-related sub-conditions since we only
+                // have age context here (height/weight checked at delivery)
+                final parts = sanitizedCondition.split('&&');
+                final ageParts = parts
+                    .where((p) => p.contains('age'))
+                    .toList();
+                if (ageParts.isEmpty) {
+                  // No age constraint in condition — treat as age-eligible
+                  ageEligibleByCondition = true;
+                  debugPrint('[EligibilityCheck] condition="$condition" has no age constraint, treating as eligible');
+                  break;
+                }
+                final ageOnlyCondition = ageParts.join('&&');
+                debugPrint('[EligibilityCheck] condition="$condition" -> ageOnly="$ageOnlyCondition" age=$totalAgeMonths');
                 final parser = FormulaParser(
-                    sanitizedCondition, {'age': totalAgeMonths});
+                    ageOnlyCondition, {'age': totalAgeMonths});
                 final result = parser.parse;
+                debugPrint('[EligibilityCheck] result: isSuccess=${result['isSuccess']}, value=${result['value']}');
                 if (result['isSuccess'] == true &&
                     result['value'] == true) {
                   ageEligibleByCondition = true;
                   break;
                 }
               } catch (e) {
-                debugPrint('Age condition evaluation error: $e');
+                debugPrint('[EligibilityCheck] Age condition evaluation error: $e');
               }
             }
             if (ageEligibleByCondition == true) break;
@@ -465,6 +482,7 @@ void initializeFunctionRegistry() {
           break;
         }
       }
+      debugPrint('[EligibilityCheck] ageEligibleByCondition=$ageEligibleByCondition');
     }
 
 // --- Tasks & SideEffects come from stateData ---


### PR DESCRIPTION
## Summary
- **Removes the v1-to-v2 translation layer** (`_searchMdmsResV2`, `_applyV1Filter`, `_v2SearchLimit`) that converted v1-style nested module/master requests into individual v2 calls and reassembled back to v1 structure
- **Adds native v2 `_searchV2` core method** that directly uses `schemaCode`, `filters`, `limit`, and `isActive` parameters
- **Fixes FormConfig performance**: Previously fetched ALL FormConfigs for ALL projects and filtered client-side; now uses v2 server-side `filters` to fetch only the selected project's configs
- **Centralizes schema code keys** using `MasterEnums`/`ModuleEnums` instead of hardcoded strings — adds new enum values (`hcmAdminConsole`, `hcmProjectTypes`, `formConfig`, `serviceRegistryMaster`, `projectTypes`)
- **Removes v1 model classes**: `MdmsModuleDetailModel`, `MdmsMasterDetailModel`, and the `getMasterDetailsModel` utility
- **Updates all callers** in `AppInitializationBloc`, `ProjectBloc`, and `enrichFormSchemasWithEnumsForForms`

## Files Changed (12)
| File | Change |
|---|---|
| `app_config_model.dart` | Updated `MdmsCriteriaModel` to v2 fields, removed v1 model classes |
| `app_config_model.freezed.dart` / `.g.dart` | Regenerated |
| `mdms.dart` | Rewrote repository with native v2 methods using enums |
| `app_initialization.dart` | Updated all MDMS caller code |
| `project.dart` | Updated callers + FormConfig performance fix |
| `utils.dart` | Removed `getMasterDetailsModel` helper |
| `mdms_master_enums.dart` / `.mapper.dart` | Added `formConfig`, `serviceRegistryMaster`, `projectTypes` |
| `mdms_module_enums.dart` / `.mapper.dart` | Added `hcmAdminConsole`, `hcmProjectTypes` |
| `mdms_v2_repository_test.dart` | Updated tests for new method signatures |

## Test plan
- [ ] `flutter build apk --release` succeeds
- [ ] App initialization loads all configs (service registry, app config, PGR definitions, dashboard)
- [ ] Project selection loads FormConfig **only** for the selected project (verify via network logs — single v2 call with `filters.project`)
- [ ] Enum enrichment in form dropdowns still populates correctly
- [ ] Service registry, project types, and row versions load correctly
- [ ] Dashboard config loads for the selected project type