### PR TITLE
Revert all-locales caching to single locale and add role action checks

### DIFF
--- a/apps/health_campaign_field_worker_app/lib/pages/home.dart
+++ b/apps/health_campaign_field_worker_app/lib/pages/home.dart
@@ -2281,7 +2281,10 @@ class _HomePageState extends LocalizedState<HomePage> {
       ),
 
       // --- Polio LQA Data Collection ---
-      if (isPolio)
+      if (isPolio &&
+          state.actionsWrapper.actions
+              .map((e) => e.displayName)
+              .contains(i18.home.polioLqaDataCollectionLabel))
         i18.home.polioLqaDataCollectionLabel:
             homeShowcaseData.polioLqaDataCollection.buildWith(
           child: HomeItemCard(
@@ -2309,7 +2312,10 @@ class _HomePageState extends LocalizedState<HomePage> {
         ),
 
       // --- Polio Inside Monitoring ---
-      if (isPolio)
+      if (isPolio &&
+          state.actionsWrapper.actions
+              .map((e) => e.displayName)
+              .contains(i18.home.polioInsideMonitoringLabel))
         i18.home.polioInsideMonitoringLabel:
             homeShowcaseData.polioInsideMonitoring.buildWith(
           child: HomeItemCard(
@@ -2911,9 +2917,7 @@ class _HomePageState extends LocalizedState<HomePage> {
                 .map((e) => e.displayName)
                 .toList()
                 .contains(element) ||
-            element == i18.home.db ||
-            (isPolio && element == i18.home.polioLqaDataCollectionLabel) ||
-            (isPolio && element == i18.home.polioInsideMonitoringLabel))
+            element == i18.home.db)
         .where(
             (element) => !(isPolio && element == i18.home.stockSyncDataLabel))
         .toList();

--- a/apps/health_campaign_field_worker_app/lib/pages/language_selection.dart
+++ b/apps/health_campaign_field_worker_app/lib/pages/language_selection.dart
@@ -18,7 +18,6 @@ import '../blocs/localization/app_localization.dart';
 import '../blocs/localization/localization.dart';
 import '../data/local_store/app_shared_preferences.dart';
 import '../data/local_store/no_sql/schema/app_configuration.dart';
-import '../data/repositories/local/localization.dart';
 import '../router/app_router.dart';
 import '../utils/environment_config.dart';
 import '../utils/i18_key_constants.dart' as i18;
@@ -34,7 +33,6 @@ class LanguageSelectionPage extends StatefulWidget {
 
 class _LanguageSelectionPageState extends State<LanguageSelectionPage> {
   bool isDialogVisible = false;
-  bool _hasLoadedAllLocales = false;
 
   @override
   void dispose() {
@@ -61,14 +59,6 @@ class _LanguageSelectionPageState extends State<LanguageSelectionPage> {
                     state.appConfiguration.backendInterface?.interfaces;
                 if (languages == null) {
                   return const Offstage();
-                }
-
-                if (!_hasLoadedAllLocales &&
-                    localizationModulesList != null) {
-                  _hasLoadedAllLocales = true;
-                  WidgetsBinding.instance.addPostFrameCallback((_) {
-                    _loadAllLocales(languages, localizationModulesList);
-                  });
                 }
 
                 return BlocConsumer<LocalizationBloc, LocalizationState>(
@@ -196,58 +186,6 @@ class _LanguageSelectionPageState extends State<LanguageSelectionPage> {
             code: locale,
           ),
         );
-  }
-
-  void _loadAllLocales(
-    List<Languages> languages,
-    List<Interfaces> localizationModulesList,
-  ) async {
-    final locBloc = context.read<LocalizationBloc>();
-    final tenantId = envConfig.variables.tenantId ?? "default";
-
-    final filteredModules = localizationModulesList
-        .where((element) =>
-            element.type == Modules.localizationModule &&
-            Constants.homeLocalizationModules.contains(element.name.toString()))
-        .map((e) => e.name.toString())
-        .join(',');
-
-    // Cache localization messages for ALL locales directly to DB.
-    await Future.wait(languages.map((language) async {
-      try {
-        final localResults =
-            await LocalizationLocalRepository().fetchLocalization(
-          sql: locBloc.sql,
-          locale: language.value,
-          module: filteredModules,
-        );
-        if (localResults.isEmpty) {
-          final results = await locBloc.localizationRepository.loadLocalization(
-            path: Constants.localizationApiPath,
-            locale: language.value,
-            module: filteredModules,
-            tenantId: tenantId,
-          );
-          await LocalizationLocalRepository().create(results, locBloc.sql);
-        }
-      } catch (e) {
-        debugPrint(
-            'error caching localization for ${language.value}: $e');
-      }
-    }));
-
-    // After caching, ensure the selected locale's strings are loaded
-    final selectedLocale = AppSharedPreferences().getSelectedLocale;
-    if (selectedLocale != null && mounted) {
-      final selectedIndex =
-          languages.indexWhere((l) => l.value == selectedLocale);
-      locBloc.add(
-        OnUpdateLocalizationIndexEvent(
-          index: selectedIndex >= 0 ? selectedIndex : 0,
-          code: selectedLocale,
-        ),
-      );
-    }
   }
 
   /// Check device RAM and show warning dialog if below 2GB, then proceed

--- a/apps/health_campaign_field_worker_app/lib/pages/project_selection.dart
+++ b/apps/health_campaign_field_worker_app/lib/pages/project_selection.dart
@@ -9,13 +9,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:isar/isar.dart';
 
-import '../blocs/app_initialization/app_initialization.dart';
 import '../blocs/auth/auth.dart';
 import '../blocs/localization/localization.dart';
 import '../blocs/project/project.dart';
 import '../data/local_store/app_shared_preferences.dart';
 import '../data/local_store/no_sql/schema/app_configuration.dart';
-import '../data/repositories/local/localization.dart';
 import '../router/app_router.dart';
 import '../utils/environment_config.dart';
 import '../utils/i18_key_constants.dart' as i18;
@@ -242,12 +240,9 @@ class _ProjectSelectionPageState extends LocalizedState<ProjectSelectionPage> {
   }
 
   void navigateToBoundary(String boundary) async {
-    final appState = context.read<AppInitializationBloc>().state;
-    final languages = (appState is AppInitialized)
-        ? (appState.appConfiguration.languages ?? [])
-        : <Languages>[];
-
     final projectReferenceId = context.selectedProject.referenceID ?? '';
+    final selectedLocale = AppSharedPreferences().getSelectedLocale!;
+    final locBloc = context.read<LocalizationBloc>();
 
     // Build module string for campaign localizations
     const moduleKey =
@@ -257,136 +252,36 @@ class _ProjectSelectionPageState extends LocalizedState<ProjectSelectionPage> {
         keys.map((key) => 'hcm-${key.toLowerCase()}-$projectReferenceId');
     final fullModuleString = moduleNames.join(',');
 
-    final selectedLocale = AppSharedPreferences().getSelectedLocale!;
-    final locBloc = context.read<LocalizationBloc>();
+    // Load campaign localizations for the selected locale only (with DB caching)
+    locBloc.add(LocalizationEvent.onLoadLocalization(
+      module: fullModuleString,
+      tenantId: envConfig.variables.tenantId,
+      locale: selectedLocale,
+      path: Constants.localizationApiPath,
+    ));
 
-    // Show loading dialog while localizations are being cached
-    DialogRoute? localizationDialogRoute;
-    if (mounted) {
-      localizationDialogRoute = DialogRoute(
-        context: context,
-        barrierDismissible: false,
-        builder: (context) => DigitSyncDialogContent(
-          type: DialogType.inProgress,
-          label: localizations.translate(
-            i18.projectSelection.syncInProgressTitleText,
-          ),
-        ),
-      );
-      Navigator.of(context, rootNavigator: true)
-          .push(localizationDialogRoute);
-    }
-
-    // Cache campaign localizations for ALL locales directly to DB.
-    final campaignCacheFuture = Future.wait(languages.map((language) async {
-      try {
-        final results = await locBloc.localizationRepository.loadLocalization(
-          path: Constants.localizationApiPath,
-          locale: language.value,
-          module: fullModuleString,
-          tenantId: envConfig.variables.tenantId,
-        );
-        await LocalizationLocalRepository().create(results, locBloc.sql);
-      } catch (e) {
-        debugPrint(
-            'error caching campaign localization for ${language.value}: $e');
-      }
-    }));
     BoundaryBloc boundaryBloc = context.read<BoundaryBloc>();
     boundaryBloc.add(BoundaryFindEvent(code: boundary));
 
     try {
-      // Wait for both campaign caching and boundary finding concurrently
-      await Future.wait([
-        campaignCacheFuture,
-        boundaryBloc.stream
-            .firstWhere((element) => element.boundaryList.isNotEmpty),
-      ]);
+      await boundaryBloc.stream
+          .firstWhere((element) => element.boundaryList.isNotEmpty);
 
-      // Cache permission handler localizations for ALL locales directly to DB
-      final permHandlerModule =
-          'hcm-permissionhandler-$projectReferenceId';
-      await Future.wait(languages.map((language) async {
-        try {
-          final localResults =
-              await LocalizationLocalRepository().fetchLocalization(
-            sql: locBloc.sql,
-            locale: language.value,
-            module: permHandlerModule,
-          );
-          if (localResults.isEmpty) {
-            final results =
-                await locBloc.localizationRepository.loadLocalization(
-              path: Constants.localizationApiPath,
-              locale: language.value,
-              module: permHandlerModule,
-              tenantId: envConfig.variables.tenantId,
-            );
-            await LocalizationLocalRepository().create(results, locBloc.sql);
-          }
-        } catch (e) {
-          debugPrint(
-              'error caching permission handler localization for ${language.value}: $e');
-        }
-      }));
-
-      // Cache boundary localizations for ALL locales. Deferred from app-boot
-      // because hierarchyType only becomes known after project selection.
-      final boundaryModule =
-          'hcm-boundary-${runtimeHierarchyType().toLowerCase()}';
-      await Future.wait(languages.map((language) async {
-        try {
-          final localResults =
-              await LocalizationLocalRepository().fetchLocalization(
-            sql: locBloc.sql,
-            locale: language.value,
-            module: boundaryModule,
-          );
-          if (localResults.isEmpty) {
-            final results =
-                await locBloc.localizationRepository.loadLocalization(
-              path: Constants.localizationApiPath,
-              locale: language.value,
-              module: boundaryModule,
-              tenantId: envConfig.variables.tenantId,
-            );
-            await LocalizationLocalRepository().create(results, locBloc.sql);
-          }
-        } catch (e) {
-          debugPrint(
-              'error caching boundary localization for ${language.value}: $e');
-        }
-      }));
-
-      // Now load the selected locale's permission handler strings via the bloc.
+      // Load permission handler localizations for selected locale (with DB caching)
       locBloc.add(LocalizationEvent.onLoadLocalization(
-        module: permHandlerModule,
+        module: 'hcm-permissionhandler-$projectReferenceId',
         tenantId: envConfig.variables.tenantId,
         locale: selectedLocale,
         path: Constants.localizationApiPath,
       ));
 
-      // Ensure the locale index is correct
-      final targetIndex =
-          languages.indexWhere((l) => l.value == selectedLocale);
-      final resolvedIndex = targetIndex >= 0 ? targetIndex : 0;
-      locBloc.add(
-        OnUpdateLocalizationIndexEvent(
-          index: resolvedIndex,
-          code: selectedLocale,
-        ),
-      );
-
-      // Wait for both bloc events to complete.
-      await locBloc.stream.firstWhere(
-        (s) => s.index == resolvedIndex && !s.loading,
-      );
-
-      // Dismiss the loading dialog before navigating
-      if (mounted && localizationDialogRoute?.isActive == true) {
-        Navigator.of(context, rootNavigator: true)
-            .removeRoute(localizationDialogRoute!);
-      }
+      // Load boundary localizations for selected locale (with DB caching)
+      locBloc.add(LocalizationEvent.onLoadLocalization(
+        module: 'hcm-boundary-${runtimeHierarchyType().toLowerCase()}',
+        tenantId: envConfig.variables.tenantId,
+        locale: selectedLocale,
+        path: Constants.localizationApiPath,
+      ));
 
       if (mounted) {
         context.router.replaceAll([
@@ -395,11 +290,6 @@ class _ProjectSelectionPageState extends LocalizedState<ProjectSelectionPage> {
       }
     } catch (e) {
       debugPrint('error $e');
-      // Dismiss the loading dialog on error too
-      if (mounted && localizationDialogRoute?.isActive == true) {
-        Navigator.of(context, rootNavigator: true)
-            .removeRoute(localizationDialogRoute!);
-      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Reverts the all-locales caching introduced in 317c83e76 so only the selected locale's localizations are loaded on language selection and project selection screens
- Uses `onLoadLocalization` (with DB caching) instead of direct repository calls, so cached modules are not re-fetched from API
- Adds role action checks for Polio LQA Data Collection and Inside Household Monitoring home cards, so they require both `isPolio` and the corresponding role action to be visible

## Test plan
- [ ] Select a language on the language selection screen — only that locale's strings should load (no all-locales caching on startup)
- [ ] Switch language — new locale loads correctly
- [ ] Select a project — campaign, permission handler, and boundary localizations load for selected locale only
- [ ] Verify boundary labels render correctly after project selection
- [ ] Polio project with LQA role action — LQA card visible
- [ ] Polio project without LQA role action — LQA card hidden
- [ ] Polio project with Inside Monitoring role action — Inside Monitoring card visible
- [ ] Polio project without Inside Monitoring role action — Inside Monitoring card hidden
- [ ] Non-polio project — LQA and Inside Monitoring cards hidden regardless of role actions